### PR TITLE
expect address to be hex-prefixed

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -10,7 +10,7 @@ describe('KeyringController', function () {
   let keyringController
   const password = 'password123'
   const seedWords = 'puzzle seed penalty soldier say clay field arctic metal hen cage runway'
-  const addresses = ['eF35cA8EbB9669A35c31b5F6f249A9941a812AC1'.toLowerCase()]
+  const addresses = ['0xeF35cA8EbB9669A35c31b5F6f249A9941a812AC1'.toLowerCase()]
   const accounts = []
   // let originalKeystore
 


### PR DESCRIPTION
behavior changed to correctly return hex-prefixed address -- however the test was not updated