### PR TITLE
Update keyring and sig-util lib versions in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-keyring-controller",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "A module for managing various keyrings of Ethereum accounts, encrypting them, and using them.",
   "main": "index.js",
   "scripts": {
@@ -36,9 +36,9 @@
     "bip39": "^2.4.0",
     "bluebird": "^3.5.0",
     "browser-passworder": "^2.0.3",
-    "eth-hd-keyring": "^1.2.0",
-    "eth-sig-util": "^1.2.2",
-    "eth-simple-keyring": "^1.1.1",
+    "eth-hd-keyring": "^1.2.1",
+    "eth-sig-util": "^1.4.0",
+    "eth-simple-keyring": "^1.2.0",
     "ethereumjs-util": "^5.1.2",
     "loglevel": "^1.5.0",
     "obs-store": "^2.4.1",


### PR DESCRIPTION
The versions of `eth-hd-keyring`, `eth-sig-util` and `eth-simple-keyring` are not up to date. In particular, the current versions do not include the changes that introduced the `signTypedData` methods. This PR brings the versions up to date with those specified in metamask's package.json.

@danfinlay @kumavis once merged, can you publish the update to npm? Thanks!

