### PR TITLE
remove race condition on unlockKeyrings output

### DIFF
--- a/index.js
+++ b/index.js
@@ -446,8 +446,8 @@ class KeyringController extends EventEmitter {
     .then((vault) => {
       this.password = password
       this.memStore.updateState({ isUnlocked: true })
-      vault.forEach(this.restoreKeyring.bind(this))
-      return this.keyrings
+      return Promise.all(vault.map(this.restoreKeyring.bind(this)))
+      .then(() => this.keyrings)
     })
   }
 


### PR DESCRIPTION
Keyrings weren't available at the return of promise of `unlockKeyrings`, making in difficult to use right after its execution. 
For example `submitPassword(xxx).then(...)` was not possible, waiting for the 'update' event neither, I had to use a timeout to make it work.
Also `submitPassword` has a `this.keyrings = keyrings` (using the return value) which is only saved by the fact that`restoreKeyrings` pushes the unlocked keyrings to a newly created this.keyrings.

hope this helps!