### PR TITLE
Require loglevel to use log

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const log = require('loglevel')
 const ethUtil = require('ethereumjs-util')
 const BN = ethUtil.BN
 const bip39 = require('bip39')

--- a/test/helper.js
+++ b/test/helper.js
@@ -4,7 +4,6 @@ enableFailureOnUnhandledPromiseRejection()
 // logging util
 var log = require('loglevel')
 log.setDefaultLevel(5)
-global.log = log
 
 //
 // polyfills


### PR DESCRIPTION
This PR requires `log`, which was previously global (before MetaMask/metamask-extension#3970)