### PR TITLE
Fix #persistAllKeyrings password binding

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,7 @@ class KeyringController extends EventEmitter {
   createNewVaultAndKeychain (password) {
     return this.persistAllKeyrings(password)
       .then(this.createFirstKeyTree.bind(this))
+      .then(this.persistAllKeyrings.bind(this, password))
       .then(this.fullUpdate.bind(this))
   }
 
@@ -313,7 +314,6 @@ class KeyringController extends EventEmitter {
       this.emit('newVault', hexAccount)
       return null
     })
-    .then(this.persistAllKeyrings.bind(this))
   }
 
   // Persist All Keyrings

--- a/test/index.js
+++ b/test/index.js
@@ -61,6 +61,21 @@ describe('KeyringController', function () {
         done(reason)
       })
     })
+
+    it('should encrypt keyrings with the correct password each time they are persisted', function (done) {
+      keyringController.store.updateState({ vault: null })
+      assert(!keyringController.store.getState().vault, 'no previous vault')
+      keyringController.createNewVaultAndKeychain(password)
+        .then(() => {
+          const vault = keyringController.store.getState().vault
+          assert(vault, 'vault created')
+          keyringController.encryptor.encrypt.args.forEach(([actualPassword]) => {
+            assert.equal(actualPassword, password)
+          })
+          done()
+        })
+        .catch(done)
+    })
   })
 
   describe('#restoreKeyring', function () {

--- a/test/lib/mock-encryptor.js
+++ b/test/lib/mock-encryptor.js
@@ -1,13 +1,13 @@
+const sinon = require('sinon')
 var mockHex = '0xabcdef0123456789'
 var mockKey = new Buffer(32)
 let cacheVal
 
 module.exports = {
-
-  encrypt (password, dataObj) {
+  encrypt: sinon.stub().callsFake(function (password, dataObj) {
     cacheVal = dataObj
     return Promise.resolve(mockHex)
-  },
+  }),
 
   decrypt (password, text) {
     return Promise.resolve(cacheVal || {})


### PR DESCRIPTION
This PR fixes the way the password value is bound for calls to `KeyringController#persistAllKeyrings`. The password argument was supposed to take on `this.password` when it was undefined, but `null` was being passed through via `#createFirstKeyTree`.

In the test cases, the call arg history for `#persistAllKeyrings` looked like so:

```
[ [ 'password123', [] ],
  [ 'password123', [ [Object] ] ],
  [ null, [ [Object] ] ],
  [ 'password123', [ [Object] ] ],
  [ 'password123', [ [Object] ] ],
  [ null, [ [Object] ] ],
  [ 'password123', [] ],
  [ 'password123', [ [Object] ] ],
  [ null, [ [Object] ] ],
  [ 'password123', [ [Object] ] ],
  [ 'password123', [ [Object] ] ],
  [ null, [ [Object] ] ] ]
```