### PR TITLE
Fix UI being updated before Store

### DIFF
--- a/index.js
+++ b/index.js
@@ -499,7 +499,7 @@ class KeyringController extends EventEmitter {
   }
 
   _updateMemStoreKeyrings () {
-    Promise.all(this.keyrings.map(this.displayForKeyring))
+    return Promise.all(this.keyrings.map(this.displayForKeyring))
     .then((keyrings) => {
       this.memStore.updateState({ keyrings })
     })


### PR DESCRIPTION
I believe I have found a bug / race condition.

Take this code for example:

```
.then(() => {
    this.keyrings.push(keyring)
    return this.persistAllKeyrings()
})
.then(() => this._updateMemStoreKeyrings())
.then(() => this.fullUpdate())
```

The intention is to update the MemStore and then emit an update with the newest MemStore. 
However, due to a bug, the old state is emitted first and then the state is updated.

Looking at the `_updateMemStoreKeyrings` method, you can see that nothing is returned. That means that it is not an async function and `fullUpdate` does not wait for `_updateMemStoreKeyrings` to finish.

You can verify this bug by placing log statements in the callback inside `_updateMemStoreKeyrings` and in  `fullUpdate`. You will see that `fullUpdate` executes first and with the old state.

I think this did not cause any malfunction in Metamask from what I can tell, but it is a bug nonetheless.