### PR TITLE
Only initialize keyring once

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,10 +158,7 @@ class KeyringController extends EventEmitter {
   addNewKeyring (type, opts) {
     const Keyring = this.getKeyringClassForType(type)
     const keyring = new Keyring(opts)
-    return keyring.deserialize(opts)
-    .then(() => {
-      return keyring.getAccounts()
-    })
+    return keyring.getAccounts()
     .then((accounts) => {
       return this.checkForDuplicate(type, accounts)
     })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-keyring-controller",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "A module for managing various keyrings of Ethereum accounts, encrypting them, and using them.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes #19

Keyrings were being initialized twice. This could potentially lead to
consumers of this library briefly thinking one mnemonic was being used
before another one was created.

This could potentially be related to https://github.com/MetaMask/metamask-extension/issues/3127