### PR TITLE
Bump eth simple keyring

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,8 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:7.10
-      
+      - image: circleci/node:8
+
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
@@ -32,7 +32,6 @@ jobs:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
-        
+
       # run tests!
       - run: yarn test
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1116,9 +1116,9 @@
       }
     },
     "eth-simple-keyring": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/eth-simple-keyring/-/eth-simple-keyring-1.2.1.tgz",
-      "integrity": "sha1-bXs1LcWppQINYfafryHvsvY2P0U=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/eth-simple-keyring/-/eth-simple-keyring-1.2.2.tgz",
+      "integrity": "sha512-uQVBYshHUOaXVoat1BpLA/QNMCr4hgdFBgwIB7rRmQ+m3vQQAseUsOM+biPDYzq6end+6LjcccElLpQaIZe6dg==",
       "requires": {
         "eth-sig-util": "^1.4.2",
         "ethereumjs-util": "^5.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -710,9 +710,9 @@
       "dev": true
     },
     "browser-stdout": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
     "browserify-aes": {
@@ -852,13 +852,10 @@
       }
     },
     "commander": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true,
-      "requires": {
-        "graceful-readlink": ">= 1.0.0"
-      }
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1281,15 +1278,15 @@
       }
     },
     "glob": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.2",
+        "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
@@ -1299,16 +1296,10 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
     },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
-    },
     "growl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
     "har-schema": {
@@ -1336,9 +1327,9 @@
       }
     },
     "has-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "hash-base": {
@@ -1581,12 +1572,6 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
-    "json3": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-      "dev": true
-    },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
@@ -1663,79 +1648,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
-    "lodash._baseassign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash.keys": "^3.0.0"
-      }
-    },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "dev": true
-    },
-    "lodash._basecreate": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
-      "dev": true
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-      "dev": true
-    },
-    "lodash.create": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true,
-      "requires": {
-        "lodash._baseassign": "^3.0.0",
-        "lodash._basecreate": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0"
-      }
-    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
-    },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
-      }
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -1844,41 +1761,46 @@
       }
     },
     "mocha": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
       "dev": true,
       "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.9.0",
-        "debug": "2.6.8",
-        "diff": "3.2.0",
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
-        "glob": "7.1.1",
-        "growl": "1.9.2",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
         "he": "1.1.1",
-        "json3": "3.3.2",
-        "lodash.create": "3.1.1",
+        "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
-        "supports-color": "3.1.2"
+        "supports-color": "5.4.0"
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
         "supports-color": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint-plugin-mocha": "^4.11.0",
     "jsdom": "^11.2.0",
     "jsdom-global": "^3.0.2",
-    "mocha": "^3.5.3",
+    "mocha": "^5.2.0",
     "mocha-sinon": "^2.0.0",
     "polyfill-crypto.getrandomvalues": "^1.0.0",
     "sinon": "^3.3.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "browser-passworder": "^2.0.3",
     "eth-hd-keyring": "^1.2.2",
     "eth-sig-util": "^1.4.0",
-    "eth-simple-keyring": "^1.2.1",
+    "eth-simple-keyring": "^1.2.2",
     "ethereumjs-util": "^5.1.2",
     "loglevel": "^1.5.0",
     "obs-store": "^2.4.1",

--- a/test/index.js
+++ b/test/index.js
@@ -74,11 +74,14 @@ describe('KeyringController', () => {
   describe('#addNewKeyring', () => {
     it('Simple Key Pair', async () => {
       const privateKey = 'c87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3'
+      const previousAccounts = await keyringController.getAccounts()
       const keyring = await keyringController.addNewKeyring('Simple Key Pair', [ privateKey ])
       const keyringAccounts = await keyring.getAccounts()
-      assert.deepEqual(keyringAccounts, ['0x627306090abab3a6e1400e9345bc60c78a8bef57'], 'keyringAccounts match expectation')
+      const expectedKeyringAccounts = ['0x627306090abab3a6e1400e9345bc60c78a8bef57']
+      assert.deepEqual(keyringAccounts, expectedKeyringAccounts, 'keyringAccounts match expectation')
       const allAccounts = await keyringController.getAccounts()
-      assert.deepEqual(allAccounts, ['0x627306090abab3a6e1400e9345bc60c78a8bef57'], 'allAccounts match expectation')
+      const expectedAllAccounts = previousAccounts.concat(expectedKeyringAccounts)
+      assert.deepEqual(allAccounts, expectedAllAccounts, 'allAccounts match expectation')
     })
   })
 

--- a/test/index.js
+++ b/test/index.js
@@ -88,6 +88,17 @@ describe('KeyringController', function () {
     })
   })
 
+  describe('#addNewKeyring', () => {
+    it('Simple Key Pair', async () => {
+      const privateKey = 'c87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3'
+      const keyring = await keyringController.addNewKeyring('Simple Key Pair', [ privateKey ])
+      const keyringAccounts = await keyring.getAccounts()
+      assert.deepEqual(keyringAccounts, ['0x627306090abab3a6e1400e9345bc60c78a8bef57'], 'keyringAccounts match expectation')
+      const allAccounts = await keyringController.getAccounts()
+      assert.deepEqual(allAccounts, ['0x627306090abab3a6e1400e9345bc60c78a8bef57'], 'allAccounts match expectation')
+    })
+  })
+
   describe('#restoreKeyring', function () {
     it(`should pass a keyring's serialized data back to the correct type.`, function (done) {
       const mockSerialized = {

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,7 @@ const BN = ethUtil.BN
 const mockEncryptor = require('./lib/mock-encryptor')
 const sinon = require('sinon')
 
-describe('KeyringController', function () {
+describe('KeyringController', () => {
   let keyringController
   const password = 'password123'
   const seedWords = 'puzzle seed penalty soldier say clay field arctic metal hen cage runway'
@@ -14,7 +14,7 @@ describe('KeyringController', function () {
   const accounts = []
   // let originalKeystore
 
-  beforeEach(function (done) {
+  beforeEach(async () => {
     this.sinon = sinon.sandbox.create()
     window.localStorage = {} // Hacking localStorage support into JSDom
 
@@ -23,17 +23,10 @@ describe('KeyringController', function () {
       encryptor: mockEncryptor,
     })
 
-    keyringController.createNewVaultAndKeychain(password)
-    .then(function (newState) {
-      newState
-      done()
-    })
-    .catch((err) => {
-      done(err)
-    })
+    const newState = await keyringController.createNewVaultAndKeychain(password)
   })
 
-  afterEach(function () {
+  afterEach(() => {
     // Cleanup mocks
     this.sinon.restore()
   })
@@ -42,7 +35,7 @@ describe('KeyringController', function () {
   describe('#submitPassword', function () {
     this.timeout(10000)
 
-    it('should not create new keyrings when called in series', async function () {
+    it('should not create new keyrings when called in series', async () => {
       await keyringController.createNewVaultAndKeychain(password)
       await keyringController.persistAllKeyrings()
 
@@ -58,33 +51,23 @@ describe('KeyringController', function () {
   describe('#createNewVaultAndKeychain', function () {
     this.timeout(10000)
 
-    it('should set a vault on the configManager', function (done) {
+    it('should set a vault on the configManager', async () => {
       keyringController.store.updateState({ vault: null })
       assert(!keyringController.store.getState().vault, 'no previous vault')
-      keyringController.createNewVaultAndKeychain(password)
-      .then(() => {
-        const vault = keyringController.store.getState().vault
-        assert(vault, 'vault created')
-        done()
-      })
-      .catch((reason) => {
-        done(reason)
-      })
+      await keyringController.createNewVaultAndKeychain(password)
+      const vault = keyringController.store.getState().vault
+      assert(vault, 'vault created')
     })
 
-    it('should encrypt keyrings with the correct password each time they are persisted', function (done) {
+    it('should encrypt keyrings with the correct password each time they are persisted', async () => {
       keyringController.store.updateState({ vault: null })
       assert(!keyringController.store.getState().vault, 'no previous vault')
-      keyringController.createNewVaultAndKeychain(password)
-        .then(() => {
-          const vault = keyringController.store.getState().vault
-          assert(vault, 'vault created')
-          keyringController.encryptor.encrypt.args.forEach(([actualPassword]) => {
-            assert.equal(actualPassword, password)
-          })
-          done()
-        })
-        .catch(done)
+      await keyringController.createNewVaultAndKeychain(password)
+      const vault = keyringController.store.getState().vault
+      assert(vault, 'vault created')
+      keyringController.encryptor.encrypt.args.forEach(([actualPassword]) => {
+        assert.equal(actualPassword, password)
+      })
     })
   })
 
@@ -99,8 +82,8 @@ describe('KeyringController', function () {
     })
   })
 
-  describe('#restoreKeyring', function () {
-    it(`should pass a keyring's serialized data back to the correct type.`, function (done) {
+  describe('#restoreKeyring', () => {
+    it(`should pass a keyring's serialized data back to the correct type.`, async () => {
       const mockSerialized = {
         type: 'HD Key Tree',
         data: {
@@ -109,38 +92,27 @@ describe('KeyringController', function () {
         },
       }
 
-      keyringController.restoreKeyring(mockSerialized)
-      .then((keyring) => {
-        assert.equal(keyring.wallets.length, 1, 'one wallet restored')
-        return keyring.getAccounts()
-      })
-      .then((accounts) => {
-        assert.equal(accounts[0], addresses[0])
-        done()
-      })
-      .catch((reason) => {
-        done(reason)
-      })
+      const keyring = await keyringController.restoreKeyring(mockSerialized)
+      assert.equal(keyring.wallets.length, 1, 'one wallet restored')
+      const accounts = await keyring.getAccounts()
+      assert.equal(accounts[0], addresses[0])
     })
   })
 
-  describe('#getAccounts', function () {
-    it('returns the result of getAccounts for each keyring', function (done) {
+  describe('#getAccounts', () => {
+    it('returns the result of getAccounts for each keyring', async () => {
       keyringController.keyrings = [
-        { getAccounts () { return Promise.resolve([1, 2, 3]) } },
-        { getAccounts () { return Promise.resolve([4, 5, 6]) } },
+        { async getAccounts () { return [1, 2, 3] } },
+        { async getAccounts () { return [4, 5, 6] } },
       ]
 
-      keyringController.getAccounts()
-      .then((result) => {
-        assert.deepEqual(result, [1, 2, 3, 4, 5, 6])
-        done()
-      })
+      const result = await keyringController.getAccounts()
+      assert.deepEqual(result, [1, 2, 3, 4, 5, 6])
     })
   })
 
-  describe('#addGasBuffer', function () {
-    it('adds 100k gas buffer to estimates', function () {
+  describe('#addGasBuffer', () => {
+    it('adds 100k gas buffer to estimates', () => {
       const gas = '0x04ee59' // Actual estimated gas example
       const tooBigOutput = '0x80674f9' // Actual bad output
       const bnGas = new BN(ethUtil.stripHexPrefix(gas), 16)
@@ -159,18 +131,14 @@ describe('KeyringController', function () {
     })
   })
 
-  describe('#unlockKeyrings', function () {
-    it('returns the list of keyrings', function (done) {
+  describe('#unlockKeyrings', () => {
+    it('returns the list of keyrings', async () => {
       keyringController.setLocked()
-      keyringController.unlockKeyrings(password)
-        .then(function (keyrings) {
-          assert.notStrictEqual(keyrings.length, 0)
-          keyrings.forEach(keyring => {
-            assert.strictEqual(keyring.wallets.length, 1)
-          })
-          done()
-        })
-        .catch(done)
+      const keyrings = await keyringController.unlockKeyrings(password)
+      assert.notStrictEqual(keyrings.length, 0)
+      keyrings.forEach(keyring => {
+        assert.strictEqual(keyring.wallets.length, 1)
+      })
     })
   })
 })


### PR DESCRIPTION
There was a discrepancy in `eth-simple-keyring` vs `eth-hd-keyring` behavior, about whether the constructor does the same thing as the `deserialize` method. `eth-keyring-controller` relies on the constructor to call the `deserialize` method in `keyringController.addNewKeyring`.

this:
- bumps eth-simple-keyring to fix that problem
- fixes tests to catch errors (async/await)
- adds a test catching the original bug