### PR TITLE
Accept keyringTypes via options param

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ class KeyringController extends EventEmitter {
   constructor (opts) {
     super()
     const initState = opts.initState || {}
-    this.keyringTypes = keyringTypes
+    this.keyringTypes = opts.keyringTypes ? keyringTypes.concat(opt.keyringTypes) : keyringTypes
     this.store = new ObservableStore(initState)
     this.memStore = new ObservableStore({
       isUnlocked: false,

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ class KeyringController extends EventEmitter {
   constructor (opts) {
     super()
     const initState = opts.initState || {}
-    this.keyringTypes = opts.keyringTypes ? keyringTypes.concat(opt.keyringTypes) : keyringTypes
+    this.keyringTypes = opts.keyringTypes ? keyringTypes.concat(opts.keyringTypes) : keyringTypes
     this.store = new ObservableStore(initState)
     this.memStore = new ObservableStore({
       isUnlocked: false,


### PR DESCRIPTION
Based on the [usage](https://github.com/MetaMask/KeyringController#usage) example, we should be able to optionally pass an array of keyringTypes