### PR TITLE
External account support Metamask issue #5640

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,7 +271,7 @@ class KeyringController extends EventEmitter {
   // extCancel contains all the transaction objects that whose signing was canceled by user
   //
   // Returns a Promise
-  upadteExternalSign (payload) {
+  updateExternalSign (payload) {
     try {
         const allowed = ['extToSign', 'extSigned', 'extCancel']
         const filtered = Object.keys(payload)

--- a/index.js
+++ b/index.js
@@ -171,8 +171,8 @@ class KeyringController extends EventEmitter {
       // try to register for external signing
       try {
         return keyring.setExtCallback(
-          this.getExternalSign.bind(this),
-          this.setExternalSign.bind(this)
+          this.getExternalState.bind(this),
+          this.setExternalState.bind(this)
         )
       } catch (e) {
         return Promise.resolve()
@@ -284,7 +284,7 @@ class KeyringController extends EventEmitter {
   // Returns a Promise
   updateExternalSign (payload) {
     try {
-      this.setExternalSign(payload)
+      this.setExternalState(payload)
       return Promise.resolve()
     } catch (e) {
       return Promise.reject(e)
@@ -303,7 +303,7 @@ class KeyringController extends EventEmitter {
   // extCancel contains all the transaction objects that whose signing was canceled by user
   //
   // Returns null
-  setExternalSign (payload) {
+  setExternalState (payload) {
     const allowed = ['extToSign', 'extSigned', 'extCancel']
     const filtered = Object.keys(payload)
       .filter(key => allowed.includes(key))
@@ -325,7 +325,7 @@ class KeyringController extends EventEmitter {
   // extCancel contains all the transaction objects that whose signing was canceled by user
   //
   // Returns the array of either extToSign, extSigned, extCancel
-  getExternalSign (key) {
+  getExternalState (key) {
     const allowed = ['extToSign', 'extSigned', 'extCancel']
     if (allowed.includes(key)) return this.memStore.getState()[key]
     else return []
@@ -525,8 +525,8 @@ class KeyringController extends EventEmitter {
       // try to register for external signing
       try {
         return keyring.setExtCallback(
-          this.getExternalSign.bind(this),
-          this.setExternalSign.bind(this)
+          this.getExternalState.bind(this),
+          this.setExternalState.bind(this)
         )
       } catch (e) {
         return Promise.resolve()

--- a/index.js
+++ b/index.js
@@ -11,9 +11,11 @@ const normalizeAddress = sigUtil.normalize
 // Keyrings:
 const SimpleKeyring = require('eth-simple-keyring')
 const HdKeyring = require('eth-hd-keyring')
+const ExternalAccontKeyring = require('eth-external-account-keyring')
 const keyringTypes = [
   SimpleKeyring,
   HdKeyring,
+  ExternalAccountKeyring
 ]
 
 class KeyringController extends EventEmitter {


### PR DESCRIPTION
We want to add external account support, which enables MEtamask not to store private keys for an external address, but upon confirm request the user will be presented with a poup modal that displays a QR code with tx data, and enables to enter a signature. Once valid signature entered, the transaction is processed by Metamask the standard way. 

Since keyrings are hidden from metamask-controller, a keyring must use keyring-controller to expose data to ui, since we want to popup a modal when a transaction is initiated from a from-address of an external account. 

This update creates three arrays of objects in KeyringController. 
`extToSign` - is used to store tx data of transactions that need to be externally signed by user. 
`extSigned` - is the storage of tx s that were successfully signed by user
`extCancel` - is the storage of tx s whose external signing was canceled by user.

Added some functions that enable controlled change of the three arrays above. 

This pr is required in order to https://github.com/MetaMask/metamask-extension/pull/6267
work properly. 