### PR TITLE
Add app key export

### DIFF
--- a/index.js
+++ b/index.js
@@ -342,16 +342,19 @@ class KeyringController extends EventEmitter {
   }
 
   // returns an app key
-  getAppKeyAddress (_address, origin) {
-      try {
-        const address = normalizeAddress(_address)
-        return this.getKeyringForAccount(address)
-          .then((keyring) => {
-            return keyring.getAppKeyAddress(address, origin)
-          })
-      } catch (e) {
-        return Promise.reject(e)
-      }
+  async getAppKeyAddress (_address, origin) {
+    const address = normalizeAddress(_address)
+    const keyring = await this.getKeyringForAccount(address)
+    return keyring.getAppKeyAddress(address, origin)
+  }
+
+  async exportAppKeyForAddress(_address, origin) {
+    const address = normalizeAddress(_address)
+    const keyring = await this.getKeyringForAccount(address)
+    if (!('exportAccount' in keyring)) {
+      throw new Error(`The keyring for address ${_address} does not support exporting.`)
+    }
+    return keyring.exportAccount(address, { withAppKeyOrigin: origin })
   }
 
   // PRIVATE METHODS

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-keyring-controller",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -336,9 +336,9 @@
       "dev": true
     },
     "base-x": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.6.tgz",
-      "integrity": "sha512-4PaF8u2+AlViJxRVjurkLTxpp7CaFRD/jo5rPT9ONnKxyhQ8f59yzamEvq7EkriG56yn5On4ONyaG75HLqr46w==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.7.tgz",
+      "integrity": "sha512-zAKJGuQPihXW22fkrfOclUUZXM2g92z5GzlSMHxhO6r6Qj+Nm0ccaGNBzDZojzwOMkpjAv4J0fOv1U4go+a4iw==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -1030,12 +1030,13 @@
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "requires": {
+        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
         "ethereumjs-util": "^5.1.1"
       },
       "dependencies": {
         "ethereumjs-abi": {
           "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
-          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
+          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
           "requires": {
             "bn.js": "^4.11.8",
             "ethereumjs-util": "^6.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -484,9 +484,9 @@
       }
     },
     "buffer": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.2.tgz",
-      "integrity": "sha512-iy9koArjAFCzGnx3ZvNA6Z0clIbbFgbdWQ0mKD3hO0krOrZh8UgA6qMKcZvwLJxS+D6iVR76+5/pV56yMNYTag==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+      "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
@@ -972,12 +972,13 @@
       "dev": true
     },
     "eth-hd-keyring": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eth-hd-keyring/-/eth-hd-keyring-2.1.0.tgz",
-      "integrity": "sha512-1ZcPmj4h18tmwG7RIturC2lpeimuiAyUGW9Ic5ztCFNeRAcfiQ3ic7sENWhzqbSgth9xkAMIHqM8IY31VJviZg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eth-hd-keyring/-/eth-hd-keyring-3.1.0.tgz",
+      "integrity": "sha512-nVLurn1eC97/IRtLATMXTGU3J4VmgREGl5WPhcHy+YehGoUImYxxeuUVBMMozFapHNY3JFfNgA06N4LHl5rWbQ==",
       "requires": {
         "bip39": "^2.2.0",
-        "eth-sig-util": "^2.0.1",
+        "eth-sig-util": "^2.4.4",
+        "eth-simple-keyring": "^3.1.0",
         "ethereumjs-abi": "^0.6.5",
         "ethereumjs-util": "^5.1.1",
         "ethereumjs-wallet": "^0.6.0",
@@ -1061,11 +1062,11 @@
       }
     },
     "eth-simple-keyring": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eth-simple-keyring/-/eth-simple-keyring-2.1.0.tgz",
-      "integrity": "sha512-31emUxGHOVhYzlPoEGyfrn1Usi2ZI9qDqMnDHwG0R0HdIuF/I10qlf401MkiD9lcMDuvgJkLpqqAvGxrKrFCwA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eth-simple-keyring/-/eth-simple-keyring-3.3.0.tgz",
+      "integrity": "sha512-CBUtcBPxZkS+qKZyuJ0lBj1ACnn1RJH6aOfGvgHo38glkQ6dHN0LRYxdzwh9uzfLMX+XzEGwJTDz4Srxcr8+iA==",
       "requires": {
-        "eth-sig-util": "^2.0.1",
+        "eth-sig-util": "^2.4.3",
         "ethereumjs-abi": "^0.6.5",
         "ethereumjs-util": "^5.1.1",
         "ethereumjs-wallet": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "bip39": "^2.4.0",
     "bluebird": "^3.5.0",
     "browser-passworder": "^2.0.3",
-    "eth-hd-keyring": "^2.1.0",
+    "eth-hd-keyring": "^3.1.0",
     "eth-sig-util": "^1.4.0",
-    "eth-simple-keyring": "^2.1.0",
+    "eth-simple-keyring": "^3.3.0",
     "ethereumjs-util": "^5.1.2",
     "loglevel": "^1.5.0",
     "obs-store": "^4.0.3"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "clone": "^2.1.1",
     "eslint": "^6.2.0",
     "eslint-plugin-mocha": "^6.0.0",
+    "ethereumjs-wallet": "^0.6.3",
     "jsdom": "^11.12.0",
     "jsdom-global": "^3.0.2",
     "mocha": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-keyring-controller",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "A module for managing various keyrings of Ethereum accounts, encrypting them, and using them.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Builds on https://github.com/MetaMask/eth-simple-keyring/pull/25 to allow exporting app keys at the keyring layer. Mostly a convenience function, but also a security measure to reduce the need to pass around the whole keyringController to allow other modules to extract app keys.