### PR TITLE
Update keyrings and switch to using `getAppKey`

### DIFF
--- a/index.js
+++ b/index.js
@@ -295,11 +295,11 @@ class KeyringController extends EventEmitter {
   // This method signs tx and returns a promise for
   // TX Manager to update the state after signing
 
-  signTransaction (ethTx, _fromAddress, opts = {}) {
+  signTransaction (ethTx, _fromAddress) {
     const fromAddress = normalizeAddress(_fromAddress)
     return this.getKeyringForAccount(fromAddress)
     .then((keyring) => {
-      return keyring.signTransaction(fromAddress, ethTx, opts)
+      return keyring.signTransaction(fromAddress, ethTx)
     })
   }
 
@@ -309,11 +309,11 @@ class KeyringController extends EventEmitter {
   // returns Promise(@buffer rawSig)
   //
   // Attempts to sign the provided @object msgParams.
-  signMessage (msgParams, opts = {}) {
+  signMessage (msgParams) {
     const address = normalizeAddress(msgParams.from)
     return this.getKeyringForAccount(address)
     .then((keyring) => {
-      return keyring.signMessage(address, msgParams.data, opts)
+      return keyring.signMessage(address, msgParams.data)
     })
   }
 
@@ -324,11 +324,11 @@ class KeyringController extends EventEmitter {
   //
   // Attempts to sign the provided @object msgParams.
   // Prefixes the hash before signing as per the new geth behavior.
-  signPersonalMessage (msgParams, opts = {}) {
+  signPersonalMessage (msgParams) {
     const address = normalizeAddress(msgParams.from)
     return this.getKeyringForAccount(address)
     .then((keyring) => {
-      return keyring.signPersonalMessage(address, msgParams.data, opts)
+      return keyring.signPersonalMessage(address, msgParams.data)
     })
   }
 
@@ -354,7 +354,7 @@ class KeyringController extends EventEmitter {
     if (!('exportAccount' in keyring)) {
       throw new Error(`The keyring for address ${_address} does not support exporting.`)
     }
-    return keyring.exportAccount(address, { withAppKeyOrigin: origin })
+    return keyring.getAppKey(address, origin)
   }
 
   // PRIVATE METHODS

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "bip39": "^2.4.0",
     "bluebird": "^3.5.0",
     "browser-passworder": "^2.0.3",
-    "eth-hd-keyring": "^3.4.0",
+    "eth-hd-keyring": "^4.0.0",
     "eth-sig-util": "^1.4.0",
-    "eth-simple-keyring": "^3.4.0",
+    "eth-simple-keyring": "^4.0.0",
     "ethereumjs-util": "^5.1.2",
     "loglevel": "^1.5.0",
     "obs-store": "^4.0.3"

--- a/test/index.js
+++ b/test/index.js
@@ -213,11 +213,11 @@ describe('KeyringController', () => {
 
       const privateAppKey = await keyringController.exportAppKeyForAddress(address, 'someapp.origin.io')
 
-      const wallet = Wallet.fromPrivateKey(ethUtil.toBuffer('0x' + privateAppKey))
+      const wallet = Wallet.fromPrivateKey(ethUtil.toBuffer('0x' + privateAppKey.toString('hex')))
       const recoveredAddress = '0x' + wallet.getAddress().toString('hex')
 
       assert.equal(recoveredAddress, appKeyAddress, 'Exported the appropriate private key')
-      assert.notEqual(privateAppKey, privateKey)
+      assert.notEqual(privateAppKey, '0x' + privateAppKey.toString('hex'))
     })
   })
 


### PR DESCRIPTION
Both `eth-simple-keyring` and `eth-hd-keyring` have been updated to `v4.0.0`. This version replaces the `withAppKeyOrigin` option with the `getAppKey` method, which returns the private app key.

Various options have also been removed, if they were used solely to pass along the removed `withAppKeyorigin` option.