### PR TITLE
Squashed commit for PR 41

### DIFF
--- a/index.js
+++ b/index.js
@@ -332,6 +332,34 @@ class KeyringController extends EventEmitter {
     })
   }
 
+  // Get encryption public key
+  // @object address
+  //
+  // returns Promise(@buffer publicKey)
+  //
+  // Get encryption public key for using in encrypt/decrypt process.
+  getEncryptionPublicKey (_address, opts = {}) {
+    const address = normalizeAddress(_address)
+    return this.getKeyringForAccount(address)
+    .then((keyring) => {
+      return keyring.getEncryptionPublicKey(address, opts)
+    })
+  }
+  
+  // Decrypt Message
+  // @object msgParams
+  //
+  // returns Promise(@buffer rawSig)
+  //
+  // Attempts to decrypt the provided @object msgParams.
+  decryptMessage (msgParams, opts = {}) {
+    const address = normalizeAddress(msgParams.from)
+    return this.getKeyringForAccount(address)
+    .then((keyring) => {
+      return keyring.decryptMessage(address, msgParams.data, opts)
+    })
+  }
+
   // Sign Typed Message (EIP712 https://github.com/ethereum/EIPs/pull/712#issuecomment-329988454)
   signTypedMessage (msgParams, opts = { version: 'V1' }) {
     const address = normalizeAddress(msgParams.from)

--- a/package-lock.json
+++ b/package-lock.json
@@ -902,12 +902,12 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
-      "integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "^1.0.0"
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "eslint-visitor-keys": {
@@ -1062,9 +1062,9 @@
       }
     },
     "eth-simple-keyring": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/eth-simple-keyring/-/eth-simple-keyring-3.4.0.tgz",
-      "integrity": "sha512-g/ObWqWaTHikrhhm7fNinpkkpEPqBRz02oBXcH81mc3VFkOLb3pjfvNg1Da6Jh+A4wA0kBE4vkiiG7BUwF1zNg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/eth-simple-keyring/-/eth-simple-keyring-3.5.0.tgz",
+      "integrity": "sha512-z9IPt9aoMWAw5Zc3Jk/HKbWPJNc7ivZ5ECNtl3ZoQUGRnwoWO71W5+liVPJtXFNacGOOGsBfqTqrXL9C4EnYYQ==",
       "requires": {
         "eth-sig-util": "^2.5.0",
         "ethereumjs-abi": "^0.6.5",
@@ -1075,9 +1075,9 @@
       },
       "dependencies": {
         "eth-sig-util": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.5.0.tgz",
-          "integrity": "sha512-ahApxr+e1cls/GwcFSGsgRLrMqG6D6cBnK9CRHhx97O/s9ow+URIxbPvov8jfE70ZnNBdHMircoSCpi1b4QHjA==",
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.5.1.tgz",
+          "integrity": "sha512-F5k+6gdSphUtHwCsj0QD59gwxxXoG+ZiFODgTiGS7xc53tPcjBSdBRuhcXdLwXGiytsjk+77oYQRRYeAKXIjBQ==",
           "requires": {
             "buffer": "^5.2.1",
             "elliptic": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "browser-passworder": "^2.0.3",
     "eth-hd-keyring": "^3.4.1",
     "eth-sig-util": "^1.4.0",
-    "eth-simple-keyring": "^3.4.0",
+    "eth-simple-keyring": "^3.5.0",
     "ethereumjs-util": "^5.1.2",
     "loglevel": "^1.5.0",
     "obs-store": "^4.0.3"


### PR DESCRIPTION
We need this feature for https://github.com/MetaMask/metamask-extension/issues/1190.
With this function, we can obtain the encryption public key for the user, that is generated via `nacl` library. Then we can store it and send encrypted messages to the user in a secure manner. The user will be able to decrypt them via "eth_decryptMessage"

https://github.com/MetaMask/KeyringController/pull/41