### PR TITLE
Only publish necessary files

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
     "ethereumjs-util": "^5.1.2",
     "loglevel": "^1.5.0",
     "obs-store": "^4.0.3"
-  }
+  },
+  "files": [
+    "index.js"
+  ]
 }


### PR DESCRIPTION
- Adds `files` property to `package.json`

New output:
```shell
npm notice === Tarball Contents === 
npm notice 21.4kB index.js    
npm notice 1.6kB  package.json
npm notice 1.8kB  README.md  
```

Previous output:
```shell
npm notice === Tarball Contents === 
npm notice 9B     .nvmrc                         
npm notice 416B   .eslintrc.js                   
npm notice 5.7kB  test/lib/config-manager.js     
npm notice 517B   test/lib/config.js             
npm notice 326B   test/lib/first-time-state.js   
npm notice 1.7kB  test/helper.js                 
npm notice 21.4kB index.js                       
npm notice 9.7kB  test/index.js                  
npm notice 310B   test/lib/mock-config-manager.js
npm notice 623B   test/lib/mock-encryptor.js     
npm notice 1.5kB  package.json                   
npm notice 3.0kB  docs/keyring.md                
npm notice 1.8kB  README.md                      
npm notice 960B   .circleci/config.yml     
```