### PR TITLE
Fix unlock event emission

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,11 +142,13 @@ class KeyringController extends EventEmitter {
    * (Pre MetaMask 3.0.0)
    * @param {string} password - The keyring controller password.
    * @returns {Promise<Object>} A Promise that resolves to the state.
+   * @emits KeyringController#unlock
    */
   submitPassword (password) {
     return this.unlockKeyrings(password)
       .then((keyrings) => {
         this.keyrings = keyrings
+        this.setUnlocked()
         return this.fullUpdate()
       })
   }
@@ -538,7 +540,6 @@ class KeyringController extends EventEmitter {
     await this.clearKeyrings()
     const vault = await this.encryptor.decrypt(password, encryptedVault)
     this.password = password
-    this.setUnlocked()
     await Promise.all(vault.map(this.restoreKeyring.bind(this)))
     return this.keyrings
   }

--- a/index.js
+++ b/index.js
@@ -115,8 +115,8 @@ class KeyringController extends EventEmitter {
         }
         return null
       })
-      .then(this.setUnlocked.bind(this))
       .then(this.persistAllKeyrings.bind(this, password))
+      .then(this.setUnlocked.bind(this))
       .then(this.fullUpdate.bind(this))
   }
 

--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ class KeyringController extends EventEmitter {
    *
    * Temporarily also migrates any old-style vaults first, as well.
    * (Pre MetaMask 3.0.0)
-   * 
+   *
    * @emits KeyringController#unlock
    * @param {string} password - The keyring controller password.
    * @returns {Promise<Object>} A Promise that resolves to the state.

--- a/test/index.js
+++ b/test/index.js
@@ -54,6 +54,19 @@ describe('KeyringController', function () {
       await keyringController.submitPassword('')
       assert.equal(keyringController.keyrings.length, 1, 'has one keyring')
     })
+
+    it('emits an unlock event', async function () {
+
+      keyringController.setLocked()
+
+      let called = false
+      keyringController.on('unlock', () => {
+        called = true
+      })
+
+      await keyringController.submitPassword(password)
+      assert.ok(called, 'unlock event fired')
+    })
   })
 
 
@@ -218,19 +231,6 @@ describe('KeyringController', function () {
       keyrings.forEach((keyring) => {
         assert.strictEqual(keyring.wallets.length, 1)
       })
-    })
-
-    it('emits an unlock event', async function () {
-
-      keyringController.setLocked()
-
-      let called = false
-      keyringController.on('unlock', () => {
-        called = true
-      })
-
-      await keyringController.unlockKeyrings(password)
-      assert.ok(called, 'unlock event fired')
     })
   })
 


### PR DESCRIPTION
- Emit `unlock` event:
  - Before persisting keyrings (as before)
  - During `submitPassword`, _after_ `this.keyrings` has been set
     - As opposed to during `unlockKeyrings`, before `this.keyrings` has been set