### PR TITLE
Add 'lock' event

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,8 +122,9 @@ class KeyringController extends EventEmitter {
 
   /**
    * Set Locked
+   * This method deallocates all secrets, and effectively locks MetaMask.
    *
-   * This method deallocates all secrets, and effectively locks metamask.
+   * @emits KeyringController#unlock
    * @returns {Promise<Object>} A Promise that resolves to the state.
    */
   async setLocked () {
@@ -133,6 +134,7 @@ class KeyringController extends EventEmitter {
     // remove keyrings
     this.keyrings = []
     await this._updateMemStoreKeyrings()
+    this.emit('lock')
     return this.fullUpdate()
   }
 
@@ -721,7 +723,7 @@ class KeyringController extends EventEmitter {
    */
   setUnlocked () {
     this.memStore.updateState({ isUnlocked: true })
-    this.emit('unlock', true)
+    this.emit('unlock')
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ class KeyringController extends EventEmitter {
    * Set Locked
    * This method deallocates all secrets, and effectively locks MetaMask.
    *
-   * @emits KeyringController#unlock
+   * @emits KeyringController#lock
    * @returns {Promise<Object>} A Promise that resolves to the state.
    */
   async setLocked () {

--- a/test/index.js
+++ b/test/index.js
@@ -66,14 +66,12 @@ describe('KeyringController', function () {
 
     it('emits "lock" event', async function () {
 
-      let called = false
-      keyringController.on('lock', () => {
-        called = true
-      })
+      const spy = sinon.spy()
+      keyringController.on('lock', spy)
 
       await keyringController.setLocked()
 
-      assert.ok(called, 'lock event fired')
+      assert.ok(spy.calledOnce, 'lock event fired')
     })
   })
 
@@ -95,13 +93,11 @@ describe('KeyringController', function () {
 
       await keyringController.setLocked()
 
-      let called = false
-      keyringController.on('unlock', () => {
-        called = true
-      })
+      const spy = sinon.spy()
+      keyringController.on('unlock', spy)
 
       await keyringController.submitPassword(password)
-      assert.ok(called, 'unlock event fired')
+      assert.ok(spy.calledOnce, 'unlock event fired')
     })
   })
 

--- a/test/index.js
+++ b/test/index.js
@@ -36,12 +36,48 @@ describe('KeyringController', function () {
   })
 
   afterEach(function () {
-    // Cleanup mocks
     sandbox.restore()
   })
 
+  describe('setLocked', function () {
 
-  describe('#submitPassword', function () {
+    it('setLocked correctly sets lock state', async function () {
+
+      assert.notDeepEqual(
+        keyringController.keyrings, [],
+        'keyrings should not be empty',
+      )
+
+      await keyringController.setLocked()
+
+      assert.equal(
+        keyringController.password, null,
+        'password should be null',
+      )
+      assert.equal(
+        keyringController.memStore.getState().isUnlocked, false,
+        'isUnlocked should be false',
+      )
+      assert.deepEqual(
+        keyringController.keyrings, [],
+        'keyrings should be empty',
+      )
+    })
+
+    it('emits "lock" event', async function () {
+
+      let called = false
+      keyringController.on('lock', () => {
+        called = true
+      })
+
+      await keyringController.setLocked()
+
+      assert.ok(called, 'lock event fired')
+    })
+  })
+
+  describe('submitPassword', function () {
 
     it('should not create new keyrings when called in series', async function () {
       await keyringController.createNewVaultAndKeychain(password)
@@ -55,9 +91,9 @@ describe('KeyringController', function () {
       assert.equal(keyringController.keyrings.length, 1, 'has one keyring')
     })
 
-    it('emits an unlock event', async function () {
+    it('emits "unlock" event', async function () {
 
-      keyringController.setLocked()
+      await keyringController.setLocked()
 
       let called = false
       keyringController.on('unlock', () => {
@@ -69,8 +105,7 @@ describe('KeyringController', function () {
     })
   })
 
-
-  describe('#createNewVaultAndKeychain', function () {
+  describe('createNewVaultAndKeychain', function () {
 
     it('should set a vault on the configManager', async function () {
 
@@ -96,7 +131,7 @@ describe('KeyringController', function () {
     })
   })
 
-  describe('#addNewKeyring', function () {
+  describe('addNewKeyring', function () {
 
     it('Simple Key Pair', async function () {
 
@@ -113,7 +148,7 @@ describe('KeyringController', function () {
     })
   })
 
-  describe('#restoreKeyring', function () {
+  describe('restoreKeyring', function () {
 
     it(`should pass a keyring's serialized data back to the correct type.`, async function () {
 
@@ -133,7 +168,7 @@ describe('KeyringController', function () {
     })
   })
 
-  describe('#getAccounts', function () {
+  describe('getAccounts', function () {
 
     it('returns the result of getAccounts for each keyring', async function () {
       keyringController.keyrings = [
@@ -154,7 +189,7 @@ describe('KeyringController', function () {
     })
   })
 
-  describe('#removeAccount', function () {
+  describe('removeAccount', function () {
 
     it('removes an account from the corresponding keyring', async function () {
 
@@ -199,7 +234,7 @@ describe('KeyringController', function () {
 
   })
 
-  describe('#addGasBuffer', function () {
+  describe('addGasBuffer', function () {
 
     it('adds 100k gas buffer to estimates', function () {
 
@@ -221,11 +256,11 @@ describe('KeyringController', function () {
     })
   })
 
-  describe('#unlockKeyrings', function () {
+  describe('unlockKeyrings', function () {
 
     it('returns the list of keyrings', async function () {
 
-      keyringController.setLocked()
+      await keyringController.setLocked()
       const keyrings = await keyringController.unlockKeyrings(password)
       assert.notStrictEqual(keyrings.length, 0)
       keyrings.forEach((keyring) => {


### PR DESCRIPTION
- Emit `lock` in `setLocked`
- Add `setLocked` tests
- Don't emit a `true` value with the `unlock` event
  - This value serves no purpose, and is not used in the extension in any event
- Minor cleanup

We require the `lock` event on the keyring controller to eliminate the `publicConfigStore` in the extension. In addition, there's already an `unlock` event on the keyring controller, and there should be a corresponding `lock` event.