### PR TITLE
Ensure memStore only updates once in unlockKeyrings

### DIFF
--- a/index.js
+++ b/index.js
@@ -546,39 +546,46 @@ class KeyringController extends EventEmitter {
     await this.clearKeyrings()
     const vault = await this.encryptor.decrypt(password, encryptedVault)
     this.password = password
-    await Promise.all(vault.map(this.restoreKeyring.bind(this)))
-    this._updateMemStoreKeyrings()
+    await Promise.all(vault.map(this._restoreKeyring.bind(this)))
+    await this._updateMemStoreKeyrings()
     return this.keyrings
   }
 
   /**
    * Restore Keyring
    *
-   * Attempts to initialize a new keyring from the provided
-   * serialized payload.
-   *
-   * On success, returns the resulting keyring instance.
-   *
-   * ATTN: The caller must call _updateMemStoreKeyrings as necessary.
+   * Attempts to initialize a new keyring from the provided serialized payload.
+   * On success, updates the memStore keyrings and returns the resulting
+   * keyring instance.
    *
    * @param {Object} serialized - The serialized keyring.
    * @returns {Promise<Keyring>} The deserialized keyring.
    */
-  restoreKeyring (serialized) {
+  async restoreKeyring (serialized) {
+    const keyring = await this._restoreKeyring(serialized)
+    await this._updateMemStoreKeyrings()
+    return keyring
+  }
+
+  /**
+   * Restore Keyring Helper
+   *
+   * Attempts to initialize a new keyring from the provided serialized payload.
+   * On success, returns the resulting keyring instance.
+   *
+   * @param {Object} serialized - The serialized keyring.
+   * @returns {Promise<Keyring>} The deserialized keyring.
+   */
+  async _restoreKeyring (serialized) {
     const { type, data } = serialized
 
     const Keyring = this.getKeyringClassForType(type)
     const keyring = new Keyring()
-    return keyring.deserialize(data)
-      .then(() => {
-        return keyring.getAccounts()
-      })
-      .then(() => {
-        this.keyrings.push(keyring)
-      })
-      .then(() => {
-        return keyring
-      })
+    await keyring.deserialize(data)
+    // getAccounts also validates the accounts for some keyrings
+    await keyring.getAccounts()
+    this.keyrings.push(keyring)
+    return keyring
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -547,6 +547,7 @@ class KeyringController extends EventEmitter {
     const vault = await this.encryptor.decrypt(password, encryptedVault)
     this.password = password
     await Promise.all(vault.map(this.restoreKeyring.bind(this)))
+    this._updateMemStoreKeyrings()
     return this.keyrings
   }
 
@@ -556,7 +557,9 @@ class KeyringController extends EventEmitter {
    * Attempts to initialize a new keyring from the provided
    * serialized payload.
    *
-   * On success, the resulting keyring instance.
+   * On success, returns the resulting keyring instance.
+   *
+   * ATTN: The caller must call _updateMemStoreKeyrings as necessary.
    *
    * @param {Object} serialized - The serialized keyring.
    * @returns {Promise<Keyring>} The deserialized keyring.
@@ -572,7 +575,6 @@ class KeyringController extends EventEmitter {
       })
       .then(() => {
         this.keyrings.push(keyring)
-        return this._updateMemStoreKeyrings()
       })
       .then(() => {
         return keyring


### PR DESCRIPTION
Previously, `restoreKeyring` called `_updateMemStoreKeyrings` for each restored keyring. This turned out to be harmful in the single instance it was called, in `unlockKeyrings`. In the extension, we had started to expect a single `memStore` update from the keyring controller on unlock, but instead we received one for each keyring in the controller.

This PR ensures that the `memStore` only updates once for each successful call to `unlockKeyrings`. We accomplish this by adding the `_restoreKeyring` helper method, which performs all the work previously done by `restoreKeyring`, except updating the `memStore`.

`unlockKeyrings` now calls `_restoreKeyring`. `restoreKeyring` remains functionally identical.