### PR TITLE
Use @metamask/eslint-config@3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/MetaMask/KeyringController#readme",
   "devDependencies": {
     "@babel/core": "^7.8.7",
-    "@metamask/eslint-config": "^2.1.0",
+    "@metamask/eslint-config": "^3.2.0",
     "clone": "^2.1.1",
     "eslint": "^6.8.0",
     "eslint-plugin-import": "^2.20.1",

--- a/test/lib/config-manager.js
+++ b/test/lib/config-manager.js
@@ -2,7 +2,6 @@ const ethUtil = require('ethereumjs-util')
 const { normalize } = require('eth-sig-util')
 const MetamaskConfig = require('./config.js')
 
-
 const MAINNET_RPC = MetamaskConfig.network.mainnet
 const ROPSTEN_RPC = MetamaskConfig.network.ropsten
 const KOVAN_RPC = MetamaskConfig.network.kovan
@@ -91,7 +90,6 @@ ConfigManager.prototype.setShowSeedWords = function (should) {
   this.setData(data)
 }
 
-
 ConfigManager.prototype.getShouldShowSeedWords = function () {
   const data = this.getData()
   return data.showSeedWords
@@ -179,7 +177,6 @@ ConfigManager.prototype.setTxList = function (txList) {
   data.transactions = txList
   this.setData(data)
 }
-
 
 // wallet nickname methods
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -119,10 +119,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@metamask/eslint-config@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-2.1.0.tgz#36b5592ed5e322750b790959517fcb4aaaff9896"
-  integrity sha512-MjpcXCeMu8hULHxqgrgtvYYsZQHpsOWM4VF4DzKMquXAfaaNgiAvcAT1lKeqYD+RobBf/kqChCu5ASysnmTC1Q==
+"@metamask/eslint-config@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-3.2.0.tgz#66b9b2bea1616821506501e76de4ac991f34914f"
+  integrity sha512-WKfB81fD5NZBFbj/UqMyfNss/b25XrukVC3j2mcaIEF0uzSKzh1b/yy7aXxcfXshWemHz28MOwZT9Bin5KV37w==
 
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.3.0", "@sinonjs/commons@^1.4.0", "@sinonjs/commons@^1.7.0":
   version "1.7.1"


### PR DESCRIPTION
This PR updates the shared ESLint config to the latest version, v3.2.0, and fixes the raised issues.