### PR TITLE
Remove unused `getNetwork` constructor option

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,6 @@ class KeyringController extends EventEmitter {
 
     this.encryptor = opts.encryptor || encryptor
     this.keyrings = []
-    this.getNetwork = opts.getNetwork
   }
 
   /**


### PR DESCRIPTION
This option was expected to be passed to the constructor, and was set on the `KeyringController` instance, but was never used.