### PR TITLE
Validate seed across all wordlists

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,9 @@ class KeyringController extends EventEmitter {
     }
 
     const wordlists = Object.values(bip39.wordlists);
-    if (wordlists.every(wordlist => !bip39.validateMnemonic(seed, wordlist))) {
+    if (
+      wordlists.every((wordlist) => !bip39.validateMnemonic(seed, wordlist))
+    ) {
       return Promise.reject(new Error('Seed phrase is invalid.'));
     }
 

--- a/index.js
+++ b/index.js
@@ -97,7 +97,8 @@ class KeyringController extends EventEmitter {
       return Promise.reject(new Error('Password must be text.'));
     }
 
-    if (!bip39.validateMnemonic(seed)) {
+    const wordlists = Object.values(bip39.wordlists);
+    if (wordlists.every(wordlist => !bip39.validateMnemonic(seed, wordlist))) {
       return Promise.reject(new Error('Seed phrase is invalid.'));
     }
 


### PR DESCRIPTION
These changes allow to use seed from any BIP39 wordlist.

_In order to spread adoption even further I think that we should allow to use words from all BIP39 wordlist languages._