### PR TITLE
v6.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-keyring-controller",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "A module for managing various keyrings of Ethereum accounts, encrypting them, and using them.",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Depends on:
#84 #83 #82 

Proposed changelog:

### changelog
* Bump elliptic from 6.5.2 to 6.5.4 (#73, #78)
* Remove unused `getNetwork` constructor option (#76)
* Bump y18n from 4.0.0 to 4.0.1 (#80)
* upgrade ethereumjs-util to 7.0.9 (#79)
* upgrade eth-sig-util to v3.0.1 (#82)
* upgrade eth-simple-keyring to v4.2.0 (#83)
* upgrade eth-hd-keyring to v3.6.0 (#84)