### PR TITLE
Add error info for getKeyringForAccount

### DIFF
--- a/index.js
+++ b/index.js
@@ -676,7 +676,19 @@ class KeyringController extends EventEmitter {
         if (winners && winners.length > 0) {
           return winners[0][0]
         }
-        throw new Error('No keyring found for the requested account.')
+
+        // Adding more info to the error
+        let errorInfo = 'Error info: '
+        if (!address) {
+          errorInfo += 'Empty address; '
+        }
+        if (!candidates || !candidates.length) {
+          errorInfo += 'Empty candidates; '
+        }
+        if (!winners || !winners.length) {
+          errorInfo += 'Empty winners;'
+        }
+        throw new Error(`No keyring found for the requested account. ${errorInfo}`)
 
       })
   }

--- a/index.js
+++ b/index.js
@@ -680,13 +680,13 @@ class KeyringController extends EventEmitter {
         // Adding more info to the error
         let errorInfo = 'Error info: '
         if (!address) {
-          errorInfo += 'Empty address; '
+          errorInfo += 'The address passed in is invalid/empty; '
         }
         if (!candidates || !candidates.length) {
-          errorInfo += 'Empty candidates; '
+          errorInfo += 'There are no keyrings; '
         }
         if (!winners || !winners.length) {
-          errorInfo += 'Empty winners;'
+          errorInfo += 'There are keyrings, but none match the address;'
         }
         throw new Error(`No keyring found for the requested account. ${errorInfo}`)
 


### PR DESCRIPTION
The mobile team has seen multiple errors coming from "No keyring found for the requested account." so this PR adds more info to that error in order to help diagnosing the problem.
Sentry error: https://sentry.io/organizations/metamask/issues/2044540268/?project=2299799&referrer=github_integration
Mobile issue: https://github.com/MetaMask/metamask-mobile/issues/2497

Resolves #86 