### PR TITLE
Remove unused `addGasBuffer` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,6 @@
-
 const { EventEmitter } = require('events')
 const log = require('loglevel')
 const ethUtil = require('ethereumjs-util')
-
-const { BN } = ethUtil
 const bip39 = require('bip39')
 const ObservableStore = require('obs-store')
 const encryptor = require('browser-passworder')
@@ -708,21 +705,6 @@ class KeyringController extends EventEmitter {
           accounts: accounts.map(normalizeAddress),
         }
       })
-  }
-
-  /**
-   * Add Gas Buffer
-   *
-   * Adds a healthy buffer of gas to an initial gas estimate.
-   *
-   * @param {string} gas - The gas value, as a hex string.
-   * @returns {string} The buffered gas, as a hex string.
-   */
-  addGasBuffer (gas) {
-    const gasBuffer = new BN('100000', 10)
-    const bnGas = new BN(ethUtil.stripHexPrefix(gas), 16)
-    const correct = bnGas.add(gasBuffer)
-    return ethUtil.addHexPrefix(correct.toString(16))
   }
 
   /**

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,5 @@
 const { strict: assert } = require('assert')
 const ethUtil = require('ethereumjs-util')
-
-const { BN } = ethUtil
 const sigUtil = require('eth-sig-util')
 
 const normalizeAddress = sigUtil.normalize
@@ -228,28 +226,6 @@ describe('KeyringController', function () {
       assert.equal(keyringController.keyrings.length, 1)
     })
 
-  })
-
-  describe('addGasBuffer', function () {
-
-    it('adds 100k gas buffer to estimates', function () {
-
-      const gas = '0x04ee59' // Actual estimated gas example
-      const tooBigOutput = '0x80674f9' // Actual bad output
-      const bnGas = new BN(ethUtil.stripHexPrefix(gas), 16)
-      const correctBuffer = new BN('100000', 10)
-      const correct = bnGas.add(correctBuffer)
-
-      // const tooBig = new BN(tooBigOutput, 16)
-      const result = keyringController.addGasBuffer(gas)
-      const bnResult = new BN(ethUtil.stripHexPrefix(result), 16)
-
-      assert.equal(result.indexOf('0x'), 0, 'included hex prefix')
-      assert(bnResult.gt(bnGas), 'Estimate increased in value.')
-      assert.equal(bnResult.sub(bnGas).toString(10), '100000', 'added 100k gas')
-      assert.equal(result, `0x${correct.toString(16)}`, 'Added the right amount')
-      assert.notEqual(result, tooBigOutput, 'not that bad estimate')
-    })
   })
 
   describe('unlockKeyrings', function () {


### PR DESCRIPTION
This method has nothing to do with keyrings, and wasn't used in either of our products. It was included in this repo since the first commit, possibly by accident.

This is a breaking change, so the release that includes this will need to be a major version bump.