### PR TITLE
Remove `ethereumjs-util` dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 const { EventEmitter } = require('events')
-const ethUtil = require('ethereumjs-util')
 const bip39 = require('bip39')
 const ObservableStore = require('obs-store')
 const encryptor = require('browser-passworder')
@@ -12,6 +11,18 @@ const keyringTypes = [
   SimpleKeyring,
   HdKeyring,
 ]
+
+/**
+ * Strip the hex prefix from an address, if present
+ * @param {string} address - The address that might be hex prefixed.
+ * @returns {string} The address without a hex prefix.
+ */
+function stripHexPrefix (address) {
+  if (address.startsWith('0x')) {
+    return address.slice(2)
+  }
+  return address
+}
 
 class KeyringController extends EventEmitter {
 
@@ -243,7 +254,7 @@ class KeyringController extends EventEmitter {
               accounts.find(
                 (key) => (
                   key === newAccountArray[0] ||
-                  key === ethUtil.stripHexPrefix(newAccountArray[0])),
+                  key === stripHexPrefix(newAccountArray[0])),
               ),
             )
             return isIncluded

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "eth-hd-keyring": "^3.6.0",
     "eth-sig-util": "^3.0.1",
     "eth-simple-keyring": "^4.2.0",
-    "ethereumjs-util": "^7.0.9",
     "obs-store": "^4.0.3"
   },
   "files": [

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,4 @@
 const { strict: assert } = require('assert')
-const ethUtil = require('ethereumjs-util')
 const sigUtil = require('eth-sig-util')
 
 const normalizeAddress = sigUtil.normalize
@@ -269,7 +268,7 @@ describe('KeyringController', function () {
 
       const privateAppKey = await keyringController.exportAppKeyForAddress(address, 'someapp.origin.io')
 
-      const wallet = Wallet.fromPrivateKey(ethUtil.toBuffer(`0x${privateAppKey}`))
+      const wallet = Wallet.fromPrivateKey(Buffer.from(privateAppKey, 'hex'))
       const recoveredAddress = `0x${wallet.getAddress().toString('hex')}`
 
       assert.equal(recoveredAddress, appKeyAddress, 'Exported the appropriate private key')


### PR DESCRIPTION
The dependency `ethereumjs-util` has been removed. It was only for a few trivial things that were easy to replace.