### PR TITLE
Remove unused `sinon` sandbox

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -11,8 +11,6 @@ const KeyringController = require('..')
 
 const mockAddress = '0xeF35cA8EbB9669A35c31b5F6f249A9941a812AC1'.toLowerCase()
 
-let sandbox
-
 describe('KeyringController', function () {
 
   let keyringController
@@ -21,7 +19,6 @@ describe('KeyringController', function () {
   const addresses = [mockAddress]
 
   beforeEach(async function () {
-    sandbox = sinon.createSandbox()
     window.localStorage = {} // Hacking localStorage support into JSDom
 
     keyringController = new KeyringController({
@@ -32,7 +29,7 @@ describe('KeyringController', function () {
   })
 
   afterEach(function () {
-    sandbox.restore()
+    sinon.restore()
   })
 
   describe('setLocked', function () {


### PR DESCRIPTION
The unused sandbox has been removed. Now the default sandbox is being restored after each test rather than the unused sandbox.