### PR TITLE
Remove `bluebird`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=12.0.0"
   },
   "scripts": {
-    "test": "mocha --timeout 10000 --require test/helper.js test/index.js",
+    "test": "mocha --timeout 10000 test/index.js",
     "lint": "eslint . --ext js,json",
     "lint:fix": "eslint . --ext js,json --fix"
   },
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "bip39": "^3.0.4",
-    "bluebird": "^3.5.0",
     "browser-passworder": "^2.0.3",
     "eth-hd-keyring": "^3.6.0",
     "eth-sig-util": "^3.0.1",

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,6 +1,0 @@
-//
-// polyfills
-//
-
-// overwrite node's promise with the stricter Bluebird promise
-global.Promise = require('bluebird')

--- a/yarn.lock
+++ b/yarn.lock
@@ -279,11 +279,6 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.0.tgz#69df92ef953aa88ca51a32df6ab1c54a155fc7a5"
   integrity sha1-ad+S75U6qIylGjLfarHFShVfx6U=
 
-bluebird@^3.5.0:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
-  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
-
 bn.js@^4.11.0, bn.js@^4.11.1, bn.js@^4.11.8, bn.js@^4.11.9:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"


### PR DESCRIPTION
`bluebird` has been removed, so we're now using native Promises everywhere. Using `bluebird` did not seem necessary; native Promises are sufficient for everything we are doing.