### PR TITLE
add forget Keyring method

### DIFF
--- a/index.js
+++ b/index.js
@@ -725,6 +725,7 @@ class KeyringController extends EventEmitter {
    * Deallocates all currently managed keyrings and accounts.
    * Used before initializing a new vault.
    */
+
   /* eslint-disable require-await */
   async clearKeyrings() {
     // clear keyrings from memory
@@ -756,6 +757,24 @@ class KeyringController extends EventEmitter {
   setUnlocked() {
     this.memStore.updateState({ isUnlocked: true });
     this.emit('unlock');
+  }
+
+  /**
+   * Forget hardware keyring
+   *
+   * Forget hardware and update memorized state.
+   * @param {Keyring} keyring
+   */
+  forgetKeyring(keyring) {
+    if (keyring.forgetDevice) {
+      keyring.forgetDevice();
+      this.persistAllKeyrings.bind(this)();
+      this._updateMemStoreKeyrings.bind(this)();
+    } else {
+      throw new Error(
+        `KeyringController - keyring does not have method "forgetDevice", keyring type: ${keyring.type}`,
+      );
+    }
   }
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -280,4 +280,27 @@ describe('KeyringController', function () {
       expect(privateAppKey).not.toBe(privateKey);
     });
   });
+
+  describe('forgetHardwareDevice', function () {
+    it('throw when keyring is not hardware device', async function () {
+      const privateKey =
+        '0xb8a9c05beeedb25df85f8d641538cbffedf67216048de9c678ee26260eb91952';
+      const keyring = await keyringController.addNewKeyring('Simple Key Pair', [
+        privateKey,
+      ]);
+      expect(keyringController.keyrings).toHaveLength(2);
+      expect(() => keyringController.forgetKeyring(keyring)).toThrow(
+        new Error(
+          'KeyringController - keyring does not have method "forgetDevice", keyring type: Simple Key Pair',
+        ),
+      );
+    });
+
+    it('forget hardware device', async function () {
+      const hdKeyring = keyringController.getKeyringsByType('HD Key Tree');
+      hdKeyring.forgetDevice = sinon.spy();
+      keyringController.forgetKeyring(hdKeyring);
+      expect(hdKeyring.forgetDevice.calledOnce).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
Fix the issue that currently MetaMask Extension did not update KeyringController state after forget device so that the addresses should be forgot still remained in redux store and displayed. 