### PR TITLE
Refactor getKeyringForAccount error flow

### DIFF
--- a/index.js
+++ b/index.js
@@ -687,18 +687,16 @@ class KeyringController extends EventEmitter {
       }
 
       // Adding more info to the error
-      let errorInfo = 'Error info: ';
+      let errorInfo = '';
       if (!address) {
-        errorInfo += 'The address passed in is invalid/empty; ';
-      }
-      if (!candidates || !candidates.length) {
-        errorInfo += 'There are no keyrings; ';
-      }
-      if (!winners || !winners.length) {
-        errorInfo += 'There are keyrings, but none match the address;';
+        errorInfo = 'The address passed in is invalid/empty';
+      } else if (!candidates || !candidates.length) {
+        errorInfo = 'There are no keyrings';
+      } else if (!winners || !winners.length) {
+        errorInfo = 'There are keyrings, but none match the address';
       }
       throw new Error(
-        `No keyring found for the requested account. ${errorInfo}`,
+        `No keyring found for the requested account. Error info: ${errorInfo}`,
       );
     });
   }

--- a/test/index.js
+++ b/test/index.js
@@ -303,4 +303,44 @@ describe('KeyringController', function () {
       expect(hdKeyring.forgetDevice.calledOnce).toBe(true);
     });
   });
+
+  describe('getKeyringForAccount', function () {
+    it('throws error when address is not provided', async function () {
+      await expect(
+        keyringController.getKeyringForAccount(undefined),
+      ).rejects.toThrow(
+        new Error(
+          'No keyring found for the requested account. Error info: The address passed in is invalid/empty',
+        ),
+      );
+    });
+
+    it('throws error when there are no keyrings', async function () {
+      keyringController.keyrings = [];
+      await expect(
+        keyringController.getKeyringForAccount('0x04'),
+      ).rejects.toThrow(
+        new Error(
+          'No keyring found for the requested account. Error info: There are no keyrings',
+        ),
+      );
+    });
+
+    it('throws error when there are no matching keyrings', async function () {
+      keyringController.keyrings = [
+        {
+          getAccounts() {
+            return Promise.resolve([1, 2, 3]);
+          },
+        },
+      ];
+      await expect(
+        keyringController.getKeyringForAccount('0x04'),
+      ).rejects.toThrow(
+        new Error(
+          'No keyring found for the requested account. Error info: There are keyrings, but none match the address',
+        ),
+      );
+    });
+  });
 });


### PR DESCRIPTION
https://sentry.io/organizations/metamask/issues/2636661006

```
No keyring found for the requested account. Error info: There are no keyrings; There are keyrings, but none match the address;
```

With the existing control flow, error messages could compound unnecessarily in cases when there were no keyrings