### PR TITLE
Fix issue where QR Code Keyring does not expect an empty options object

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,10 +198,10 @@ class KeyringController extends EventEmitter {
    * @param {Object} opts - The constructor options for the keyring.
    * @returns {Promise<Keyring>} The new keyring.
    */
-  addNewKeyring(type, opts = {}) {
+  addNewKeyring(type, opts) {
     const Keyring = this.getKeyringClassForType(type);
     const keyring = new Keyring(opts);
-    if (!opts.mnemonic && type === KEYRINGS_TYPE_MAP.HD_KEYRING) {
+    if ((!opts || !opts.mnemonic) && type === KEYRINGS_TYPE_MAP.HD_KEYRING) {
       keyring.generateRandomMnemonic();
       keyring.addAccounts();
     }


### PR DESCRIPTION
Fixes a bug I introduced with KeyringController's interface with QR hardware wallet Keyring 
`@keystonerhq/base-eth-keyring` doesn't appear to be public on github... but if you look in node_modules (`node_modules/@keystonehq/base-eth-keyring/dist/base-eth-keyring.cjs.development.js`) line 300, the `deserialize` method does not expect an empty object as it's `opts` argument.


This issue became apparent in the QR hardware [keyring tests implemented in Controllers](https://github.com/MetaMask/controllers/blob/main/src/keyring/KeyringController.test.ts#L503)