### PR TITLE
Patch KeyringController to accept seedphrases passed as buffers/arrays of numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write"
   },
   "dependencies": {
+    "@metamask/bip39": "^4.0.0",
     "@metamask/eth-hd-keyring": "^4.0.2",
-    "bip39": "^3.0.4",
     "browser-passworder": "^2.0.3",
     "eth-sig-util": "^3.0.1",
     "eth-simple-keyring": "^4.2.0",

--- a/test/index.js
+++ b/test/index.js
@@ -142,6 +142,23 @@ describe('KeyringController', function () {
         ),
       ).rejects.toThrow('Seed phrase is invalid.');
     });
+
+    it('accepts mnemonic passed as type array of numbers', async function () {
+      const allAccountsBefore = await keyringController.getAccounts();
+      expect(allAccountsBefore[0]).not.toBe(walletTwoAddresses[0]);
+      const mnemonicAsArrayOfNumbers = Array.from(
+        Buffer.from(walletTwoSeedWords).values(),
+      );
+
+      await keyringController.createNewVaultAndRestore(
+        password,
+        mnemonicAsArrayOfNumbers,
+      );
+
+      const allAccountsAfter = await keyringController.getAccounts();
+      expect(allAccountsAfter).toHaveLength(1);
+      expect(allAccountsAfter[0]).toBe(walletTwoAddresses[0]);
+    });
   });
 
   describe('addNewKeyring', function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1162,16 +1162,6 @@ bindings@^1.2.1, bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-bip39@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/bip39/-/bip39-3.0.4.tgz#5b11fed966840b5e1b8539f0f54ab6392969b2a0"
-  integrity sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw==
-  dependencies:
-    "@types/node" "11.11.6"
-    create-hash "^1.1.0"
-    pbkdf2 "^3.0.9"
-    randombytes "^2.0.1"
-
 bip66@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/bip66/-/bip66-1.1.5.tgz#01fa8748785ca70955d5011217d1b3139969ca22"


### PR DESCRIPTION
Patch KeyringController  such that `createNewVaultAndRestore` accepts `seedphrase` arg as either type string or array of type number, and passes to addNewKeyring as a buffer.

Updates package to use `@metamask` version of `bip39` that also accepts `seedphrase`s passed as buffers to `validateMnemonic`.

`metamask-extension` already implements this patch [here](https://github.com/MetaMask/metamask-extension/blob/develop/patches/eth-keyring-controller%2B6.2.1.patch) & [here](https://github.com/MetaMask/metamask-extension/blob/develop/patches/bip39%2B2.5.0.patch) (to be removed when this is cut into a release and pulled into the extension)
