### PR TITLE
Updated Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The KeyringController has three main responsibilities:
 
 ## Installation
 
-`yarn install eth-keyring-controller --save`
+`yarn add eth-keyring-controller`
 
 ## Usage
 


### PR DESCRIPTION
#142 

Solved issue of wrong syntax for installing dependency using yarn in readme.