### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Currently the methods are heavily commented in [the source code](./index.js), so
 - Install [Node.js](https://nodejs.org) version 12
   - If you are using [nvm](https://github.com/creationix/nvm#installation) (recommended) running `nvm use` will automatically choose the right node version for you.
 - Install [Yarn v1](https://yarnpkg.com/en/docs/install)
-- Run `yarn setup` to install dependencies and run any requried post-install scripts
+- Run `yarn setup` to install dependencies and run any required post-install scripts
   - **Warning:** Do not use the `yarn` / `yarn install` command directly. Use `yarn setup` instead. The normal install command will skip required post-install scripts, leaving your development environment in an invalid state.
 
 ### Testing and Linting


### PR DESCRIPTION
There is a typo in the README file ("requried") 
The spelling should be updated to "required" 