### PR TITLE
Fixed a typo in the duplicate account import error

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,7 +271,7 @@ class KeyringController extends EventEmitter {
 
         if (isIncluded) {
           throw new Error(
-            "The account you are trying to import is a duplicate",
+            'The account you are trying to import is a duplicate',
           );
         }
         return newAccountArray;

--- a/index.js
+++ b/index.js
@@ -271,7 +271,7 @@ class KeyringController extends EventEmitter {
 
         if (isIncluded) {
           throw new Error(
-            "The account you're are trying to import is a duplicate",
+            "The account you are trying to import is a duplicate",
           );
         }
         return newAccountArray;


### PR DESCRIPTION
Today when I was using MetaMask I noticed that the following unlocalized typo gets surfaced to end users who attempt to import a duplicate account. This PR simply fixes the typo, thus fixing the MetaMask issue https://github.com/MetaMask/metamask-extension/issues/16370. Merging this pull request will break a downstream MetaMask test case that expects the typo, so I have also fixed the test case separately in the pull request https://github.com/MetaMask/metamask-extension/pull/16371.