### PR TITLE
Ensure newly created vaults are unlocked

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ class KeyringController extends EventEmitter {
   async createNewVaultAndKeychain(password) {
     await this.createFirstKeyTree(password);
     await this.persistAllKeyrings(password);
-    this.setUnlocked.bind();
+    this.setUnlocked();
     this.fullUpdate();
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -85,7 +85,7 @@ describe('KeyringController', function () {
   });
 
   describe('createNewVaultAndKeychain', function () {
-    it('should set a vault on the configManager', async function () {
+    it('should create a new vault', async function () {
       keyringController.store.updateState({ vault: null });
       assert(!keyringController.store.getState().vault, 'no previous vault');
 
@@ -93,6 +93,15 @@ describe('KeyringController', function () {
       const { vault } = keyringController.store.getState();
       // eslint-disable-next-line jest/no-restricted-matchers
       expect(vault).toBeTruthy();
+    });
+
+    it('should unlock the vault', async function () {
+      keyringController.store.updateState({ vault: null });
+      assert(!keyringController.store.getState().vault, 'no previous vault');
+
+      await keyringController.createNewVaultAndKeychain(password);
+      const { isUnlocked } = keyringController.memStore.getState();
+      expect(isUnlocked).toBe(true);
     });
 
     it('should encrypt keyrings with the correct password each time they are persisted', async function () {


### PR DESCRIPTION
A new vault should be unlocked after being created, because the password is submitted as part of creating the vault. This was accidentally broken as part of #148. A unit test has been added to ensure this doesn't happen again.