### PR TITLE
Return fullUpdate from methods it used to

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ class KeyringController extends EventEmitter {
 
     await this.createFirstKeyTree();
     this.setUnlocked();
-    this.fullUpdate();
+    return this.fullUpdate();
   }
 
   /**
@@ -182,7 +182,7 @@ class KeyringController extends EventEmitter {
     this.keyrings = await this.unlockKeyrings(password);
 
     this.setUnlocked();
-    this.fullUpdate();
+    return this.fullUpdate();
   }
 
   /**
@@ -203,7 +203,7 @@ class KeyringController extends EventEmitter {
       encryptionSalt,
     );
     this.setUnlocked();
-    this.fullUpdate();
+    return this.fullUpdate();
   }
 
   /**
@@ -330,7 +330,7 @@ class KeyringController extends EventEmitter {
     });
 
     await this.persistAllKeyrings();
-    this.fullUpdate();
+    return this.fullUpdate();
   }
 
   /**
@@ -379,7 +379,7 @@ class KeyringController extends EventEmitter {
     }
 
     await this.persistAllKeyrings();
-    this.fullUpdate();
+    return this.fullUpdate();
   }
 
   //

--- a/test/index.js
+++ b/test/index.js
@@ -99,10 +99,12 @@ describe('KeyringController', function () {
       keyringController.store.updateState({ vault: null });
       assert(!keyringController.store.getState().vault, 'no previous vault');
 
-      await keyringController.createNewVaultAndKeychain(password);
+      const newVault = await keyringController.createNewVaultAndKeychain(
+        password,
+      );
       const { vault } = keyringController.store.getState();
-      // eslint-disable-next-line jest/no-restricted-matchers
-      expect(vault).toBeTruthy();
+      expect(vault).toStrictEqual(expect.stringMatching('.+'));
+      expect(typeof newVault).toBe('object');
     });
 
     it('should unlock the vault', async function () {


### PR DESCRIPTION
After seeing a test failure in the extension, I noticed that `createNewVaultAndKeychain` wasn't returning the vault like it used to before https://github.com/MetaMask/KeyringController/commit/e797bdf51b651dd8308e4535fdcb5896f1025073.  This fixes the issue.