### PR TITLE
Fix: saving serialized keyring for which corresponding keyring class is not present

### DIFF
--- a/index.js
+++ b/index.js
@@ -563,7 +563,9 @@ class KeyringController extends EventEmitter {
       }),
     );
 
-    this.unsupported_keyrings.forEach(keyring => serializedKeyrings.push(keyring));
+    this.unsupported_keyrings.forEach((keyring) =>
+      serializedKeyrings.push(keyring),
+    );
 
     let vault;
     let newEncryptionKey;
@@ -702,8 +704,8 @@ class KeyringController extends EventEmitter {
 
     const Keyring = this.getKeyringClassForType(type);
     if (!Keyring) {
-      unsupported_keyrings.push(serialized);
-      return;
+      this.unsupported_keyrings.push(serialized);
+      return undefined;
     }
     const keyring = new Keyring();
     await keyring.deserialize(data);

--- a/index.js
+++ b/index.js
@@ -43,12 +43,12 @@ class KeyringController extends EventEmitter {
       isUnlocked: false,
       keyringTypes: this.keyringTypes.map((keyringType) => keyringType.type),
       keyrings: [],
-      unsupported_keyrings: [],
       encryptionKey: null,
     });
 
     this.encryptor = opts.encryptor || encryptor;
     this.keyrings = [];
+    this.unsupported_keyrings = [];
 
     // This option allows the controller to cache an exported key
     // for use in decrypting and encrypting data without password

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ class KeyringController extends EventEmitter {
 
     this.encryptor = opts.encryptor || encryptor;
     this.keyrings = [];
-    this.unsupported_keyrings = [];
+    this.unsupportedKeyrings = [];
 
     // This option allows the controller to cache an exported key
     // for use in decrypting and encrypting data without password
@@ -563,7 +563,7 @@ class KeyringController extends EventEmitter {
       }),
     );
 
-    serializedKeyrings.push(...this.unsupported_keyrings);
+    serializedKeyrings.push(...this.unsupportedKeyrings);
 
     let vault;
     let newEncryptionKey;
@@ -695,14 +695,14 @@ class KeyringController extends EventEmitter {
    * On success, returns the resulting keyring instance.
    *
    * @param {Object} serialized - The serialized keyring.
-   * @returns {Promise<Keyring>} The deserialized keyring.
+   * @returns {Promise<Keyring|undefined>} The deserialized keyring or undefined if the keyring type is unsupported.
    */
   async _restoreKeyring(serialized) {
     const { type, data } = serialized;
 
     const Keyring = this.getKeyringClassForType(type);
     if (!Keyring) {
-      this.unsupported_keyrings.push(serialized);
+      this.unsupportedKeyrings.push(serialized);
       return undefined;
     }
     const keyring = new Keyring();

--- a/index.js
+++ b/index.js
@@ -563,9 +563,7 @@ class KeyringController extends EventEmitter {
       }),
     );
 
-    this.unsupported_keyrings.forEach((keyring) =>
-      serializedKeyrings.push(keyring),
-    );
+    serializedKeyrings.push(...this.unsupported_keyrings);
 
     let vault;
     let newEncryptionKey;

--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ class KeyringController extends EventEmitter {
       isUnlocked: false,
       keyringTypes: this.keyringTypes.map((keyringType) => keyringType.type),
       keyrings: [],
+      unsupported_keyrings: [],
       encryptionKey: null,
     });
 
@@ -562,6 +563,8 @@ class KeyringController extends EventEmitter {
       }),
     );
 
+    this.unsupported_keyrings.forEach(keyring => serializedKeyrings.push(keyring));
+
     let vault;
     let newEncryptionKey;
 
@@ -699,7 +702,8 @@ class KeyringController extends EventEmitter {
 
     const Keyring = this.getKeyringClassForType(type);
     if (!Keyring) {
-      return
+      unsupported_keyrings.push(serialized);
+      return;
     }
     const keyring = new Keyring();
     await keyring.deserialize(data);

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ class KeyringController extends EventEmitter {
 
     this.encryptor = opts.encryptor || encryptor;
     this.keyrings = [];
-    this.unsupportedKeyrings = [];
+    this._unsupportedKeyrings = [];
 
     // This option allows the controller to cache an exported key
     // for use in decrypting and encrypting data without password
@@ -563,7 +563,7 @@ class KeyringController extends EventEmitter {
       }),
     );
 
-    serializedKeyrings.push(...this.unsupportedKeyrings);
+    serializedKeyrings.push(...this._unsupportedKeyrings);
 
     let vault;
     let newEncryptionKey;
@@ -702,7 +702,7 @@ class KeyringController extends EventEmitter {
 
     const Keyring = this.getKeyringClassForType(type);
     if (!Keyring) {
-      this.unsupportedKeyrings.push(serialized);
+      this._unsupportedKeyrings.push(serialized);
       return undefined;
     }
     const keyring = new Keyring();

--- a/index.js
+++ b/index.js
@@ -679,7 +679,9 @@ class KeyringController extends EventEmitter {
    */
   async restoreKeyring(serialized) {
     const keyring = await this._restoreKeyring(serialized);
-    await this._updateMemStoreKeyrings();
+    if (keyring) {
+      await this._updateMemStoreKeyrings();
+    }
     return keyring;
   }
 
@@ -696,6 +698,9 @@ class KeyringController extends EventEmitter {
     const { type, data } = serialized;
 
     const Keyring = this.getKeyringClassForType(type);
+    if (!Keyring) {
+      return
+    }
     const keyring = new Keyring();
     await keyring.deserialize(data);
     // getAccounts also validates the accounts for some keyrings

--- a/test/index.js
+++ b/test/index.js
@@ -353,13 +353,14 @@ describe('KeyringController', function () {
       });
     });
     it('add serialized keyring to unsupportedKeyrings array if keyring type is not known', async function () {
-      mockEncryptor.encrypt(password, [
-        { type: 'Ledger Keyring', data: 'DUMMY' },
-      ]);
+      const unsupportedKeyrings = [{ type: 'Ledger Keyring', data: 'DUMMY' }];
+      mockEncryptor.encrypt(password, unsupportedKeyrings);
       await keyringController.setLocked();
       const keyrings = await keyringController.unlockKeyrings(password);
       expect(keyrings).toHaveLength(0);
-      expect(keyringController.unsupportedKeyrings).toHaveLength(1);
+      expect(keyringController.unsupportedKeyrings).toStrictEqual(
+        unsupportedKeyrings,
+      );
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -359,7 +359,7 @@ describe('KeyringController', function () {
       await keyringController.setLocked();
       const keyrings = await keyringController.unlockKeyrings(password);
       expect(keyrings).toHaveLength(0);
-      expect(keyringController.unsupported_keyrings).toHaveLength(1);
+      expect(keyringController.unsupported_keyrings).toStrictEqual(keyrings);
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -95,9 +95,9 @@ describe('KeyringController', function () {
   });
 
   describe('persistAllKeyrings', function () {
-    it('should persist keyrings in unsupported_keyrings array', async function () {
+    it('should persist keyrings in unsupportedKeyrings array', async function () {
       const unsupportedKeyring = 'DUMMY_KEYRING';
-      keyringController.unsupported_keyrings = [unsupportedKeyring];
+      keyringController.unsupportedKeyrings = [unsupportedKeyring];
       await keyringController.persistAllKeyrings();
       const { vault } = keyringController.store.getState();
       const keyrings = await mockEncryptor.decrypt(password, vault);
@@ -352,14 +352,14 @@ describe('KeyringController', function () {
         expect(keyring.wallets).toHaveLength(1);
       });
     });
-    it('add serialized keyring to unsupported_keyrings array if keyring type is not known', async function () {
+    it('add serialized keyring to unsupportedKeyrings array if keyring type is not known', async function () {
       mockEncryptor.encrypt(password, [
         { type: 'Ledger Keyring', data: 'DUMMY' },
       ]);
       await keyringController.setLocked();
       const keyrings = await keyringController.unlockKeyrings(password);
       expect(keyrings).toHaveLength(0);
-      expect(keyringController.unsupported_keyrings).toStrictEqual(keyrings);
+      expect(keyringController.unsupportedKeyrings).toStrictEqual(keyrings);
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -95,9 +95,9 @@ describe('KeyringController', function () {
   });
 
   describe('persistAllKeyrings', function () {
-    it('should persist keyrings in unsupportedKeyrings array', async function () {
+    it('should persist keyrings in _unsupportedKeyrings array', async function () {
       const unsupportedKeyring = 'DUMMY_KEYRING';
-      keyringController.unsupportedKeyrings = [unsupportedKeyring];
+      keyringController._unsupportedKeyrings = [unsupportedKeyring];
       await keyringController.persistAllKeyrings();
       const { vault } = keyringController.store.getState();
       const keyrings = await mockEncryptor.decrypt(password, vault);
@@ -267,6 +267,13 @@ describe('KeyringController', function () {
       const accounts = await keyring.getAccounts();
       expect(accounts[0]).toBe(walletOneAddresses[0]);
     });
+    it('should return undefined if keyring type is not supported.', async function () {
+      const unsupportedKeyring = { type: 'Ledger Keyring', data: 'DUMMY' };
+      const keyring = await keyringController.restoreKeyring(
+        unsupportedKeyring,
+      );
+      expect(keyring).toBeUndefined();
+    });
   });
 
   describe('getAccounts', function () {
@@ -352,14 +359,14 @@ describe('KeyringController', function () {
         expect(keyring.wallets).toHaveLength(1);
       });
     });
-    it('add serialized keyring to unsupportedKeyrings array if keyring type is not known', async function () {
-      const unsupportedKeyrings = [{ type: 'Ledger Keyring', data: 'DUMMY' }];
-      mockEncryptor.encrypt(password, unsupportedKeyrings);
+    it('add serialized keyring to _unsupportedKeyrings array if keyring type is not known', async function () {
+      const _unsupportedKeyrings = [{ type: 'Ledger Keyring', data: 'DUMMY' }];
+      mockEncryptor.encrypt(password, _unsupportedKeyrings);
       await keyringController.setLocked();
       const keyrings = await keyringController.unlockKeyrings(password);
       expect(keyrings).toHaveLength(0);
-      expect(keyringController.unsupportedKeyrings).toStrictEqual(
-        unsupportedKeyrings,
+      expect(keyringController._unsupportedKeyrings).toStrictEqual(
+        _unsupportedKeyrings,
       );
     });
   });

--- a/test/index.js
+++ b/test/index.js
@@ -359,7 +359,7 @@ describe('KeyringController', function () {
       await keyringController.setLocked();
       const keyrings = await keyringController.unlockKeyrings(password);
       expect(keyrings).toHaveLength(0);
-      expect(keyringController.unsupportedKeyrings).toStrictEqual(keyrings);
+      expect(keyringController.unsupportedKeyrings).toHaveLength(1);
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -101,7 +101,7 @@ describe('KeyringController', function () {
       await keyringController.persistAllKeyrings();
       const { vault } = keyringController.store.getState();
       const keyrings = await mockEncryptor.decrypt(password, vault);
-      expect(keyrings.indexOf(unsupportedKeyring) > -1).toBeTruthy();
+      expect(keyrings.indexOf(unsupportedKeyring) > -1).toBe(true);
       expect(keyrings).toHaveLength(2);
     });
 


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/16674

For MV3 currently we are not supporting hardware wallets, this can result in error being thrown if Keyring classes of hardware wallets is not passed to Keyring Controller.

PR fixes the error by adding `null` check. Keyring for which corresponding keyring class is not present is saved in state and then re-serialized.