### PR TITLE
await for addAccounts for HD Keyring

### DIFF
--- a/index.js
+++ b/index.js
@@ -247,7 +247,7 @@ class KeyringController extends EventEmitter {
 
     if ((!opts || !opts.mnemonic) && type === KEYRINGS_TYPE_MAP.HD_KEYRING) {
       keyring.generateRandomMnemonic();
-      keyring.addAccounts();
+      await keyring.addAccounts();
     }
 
     const accounts = await keyring.getAccounts();

--- a/test/index.js
+++ b/test/index.js
@@ -280,6 +280,59 @@ describe('KeyringController', function () {
 
       sinon.assert.calledOnce(initSpy);
     });
+
+    it('should finish adding HD Keyring accounts before continuing execution', async function () {
+      let timeoutSet = false;
+      let addAccountsResolved = false;
+
+      const originalAccAccounts = HdKeyring.prototype.addAccounts;
+      sinon.stub(HdKeyring.prototype, 'addAccounts').callsFake(function () {
+        return new Promise((resolve) => {
+          originalAccAccounts
+            .bind(this)()
+            .then((accounts) => {
+              setTimeout(() => {
+                addAccountsResolved = true;
+                resolve(accounts);
+              }, 100);
+
+              timeoutSet = true;
+            });
+        });
+      });
+
+      const originalGetAccounts = HdKeyring.prototype.getAccounts;
+      sinon.stub(HdKeyring.prototype, 'getAccounts').callsFake(function () {
+        return new Promise((resolve, rejects) => {
+          if (!addAccountsResolved) {
+            rejects(
+              new Error('Should not be called before accounts are added'),
+            );
+          }
+
+          originalGetAccounts
+            .bind(this)()
+            .then((accounts) => {
+              resolve(accounts);
+            });
+        });
+      });
+
+      const keyringPromise = keyringController.addNewKeyring('HD Key Tree');
+
+      await new Promise((resolve) => {
+        const timer = setInterval(() => {
+          if (timeoutSet) {
+            clearInterval(timer);
+            resolve();
+          }
+        }, 50);
+      });
+
+      const keyring = await keyringPromise;
+
+      expect(keyring).toBeInstanceOf(HdKeyring);
+    });
   });
 
   describe('restoreKeyring', function () {


### PR DESCRIPTION
Adds missing `await` to an asynchronous call that adds accounts to a new HD Keyring.

It also includes a unit test to validate that we are awaiting for that call.