### PR TITLE
bump @metamask/eth-sig-util to latest

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const { Buffer } = require('buffer');
 const bip39 = require('@metamask/bip39');
 const ObservableStore = require('obs-store');
 const encryptor = require('@metamask/browser-passworder');
-const { normalize: normalizeAddress } = require('eth-sig-util');
+const { normalize: normalizeAddress } = require('@metamask/eth-sig-util');
 
 const SimpleKeyring = require('@metamask/eth-simple-keyring');
 const HdKeyring = require('@metamask/eth-hd-keyring');

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "@metamask/bip39": "^4.0.0",
     "@metamask/browser-passworder": "^4.0.1",
     "@metamask/eth-hd-keyring": "^4.0.2",
+    "@metamask/eth-sig-util": "5.0.2",
     "@metamask/eth-simple-keyring": "^5.0.0",
-    "eth-sig-util": "^3.0.1",
     "obs-store": "^4.0.3"
   },
   "devDependencies": {
@@ -65,7 +65,9 @@
       "eth-sig-util>ethereumjs-util>keccak": false,
       "eth-sig-util>ethereumjs-util>secp256k1": false,
       "ethereumjs-wallet>ethereum-cryptography>keccak": false,
-      "ethereumjs-wallet>ethereum-cryptography>secp256k1": false
+      "ethereumjs-wallet>ethereum-cryptography>secp256k1": false,
+      "@metamask/eth-hd-keyring>eth-simple-keyring>eth-sig-util>ethereumjs-util>keccak": false,
+      "@metamask/eth-hd-keyring>eth-simple-keyring>eth-sig-util>ethereumjs-util>secp256k1": false
     }
   },
   "packageManager": "yarn@3.2.4"

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 const { strict: assert } = require('assert');
-const sigUtil = require('eth-sig-util');
+const sigUtil = require('@metamask/eth-sig-util');
 
 const normalizeAddress = sigUtil.normalize;
 const sinon = require('sinon');

--- a/yarn.lock
+++ b/yarn.lock
@@ -826,20 +826,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-sig-util@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "@metamask/eth-sig-util@npm:4.0.1"
-  dependencies:
-    ethereumjs-abi: ^0.6.8
-    ethereumjs-util: ^6.2.1
-    ethjs-util: ^0.1.6
-    tweetnacl: ^1.0.3
-    tweetnacl-util: ^0.15.1
-  checksum: 740df4c92a1282e6be4c00c86c1a8ccfb93e767596e43f6da895aa5bab4a28fc3c2209f0327db34924a4a1e9db72bc4d3dddfcfc45cca0b218c9ccbf7d1b1445
-  languageName: node
-  linkType: hard
-
-"@metamask/eth-sig-util@npm:^5.0.1":
+"@metamask/eth-sig-util@npm:5.0.2, @metamask/eth-sig-util@npm:^5.0.1":
   version: 5.0.2
   resolution: "@metamask/eth-sig-util@npm:5.0.2"
   dependencies:
@@ -850,6 +837,19 @@ __metadata:
     tweetnacl: ^1.0.3
     tweetnacl-util: ^0.15.1
   checksum: 1fbf1a0f5e654058f0219c9018dbebadf53036c9c3b47c8faf1cac54816532bb18996821736f526ac4e3d579afcaf502af4ad07e88158a50f015141858b08a90
+  languageName: node
+  linkType: hard
+
+"@metamask/eth-sig-util@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "@metamask/eth-sig-util@npm:4.0.1"
+  dependencies:
+    ethereumjs-abi: ^0.6.8
+    ethereumjs-util: ^6.2.1
+    ethjs-util: ^0.1.6
+    tweetnacl: ^1.0.3
+    tweetnacl-util: ^0.15.1
+  checksum: 740df4c92a1282e6be4c00c86c1a8ccfb93e767596e43f6da895aa5bab4a28fc3c2209f0327db34924a4a1e9db72bc4d3dddfcfc45cca0b218c9ccbf7d1b1445
   languageName: node
   linkType: hard
 
@@ -2834,6 +2834,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^10.0.0
     "@metamask/eslint-config-nodejs": ^10.0.0
     "@metamask/eth-hd-keyring": ^4.0.2
+    "@metamask/eth-sig-util": 5.0.2
     "@metamask/eth-simple-keyring": ^5.0.0
     eslint: ^8.21.0
     eslint-config-prettier: ^8.3.0
@@ -2842,7 +2843,6 @@ __metadata:
     eslint-plugin-jsdoc: ^39.2.9
     eslint-plugin-node: ^11.1.0
     eslint-plugin-prettier: ^4.2.1
-    eth-sig-util: ^3.0.1
     ethereumjs-wallet: ^1.0.1
     jest: ^27.0.6
     obs-store: ^4.0.3


### PR DESCRIPTION
Bumps `eth-sig-util` to (newly named) `@metamask/eth-sig-util` v5.0.2 (latest)