### PR TITLE
Update `@metamask/browser-passworder`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write"
   },
   "dependencies": {
-    "@metamask/browser-passworder": "^4.0.1",
+    "@metamask/browser-passworder": "^4.0.2",
     "@metamask/eth-hd-keyring": "^5.0.1",
     "@metamask/eth-sig-util": "5.0.2",
     "@metamask/eth-simple-keyring": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -758,7 +758,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/browser-passworder@npm:^4.0.1":
+"@metamask/browser-passworder@npm:^4.0.2":
   version: 4.0.2
   resolution: "@metamask/browser-passworder@npm:4.0.2"
   checksum: 997c330b1c72f7135d0fd2a7f4b0dce37b3c2e6b30e92f048fa8d4f8c949f5b669dcc3064790f41df30ee2e53a9e64a812df72e00527736be704cce2cf4f6e49
@@ -2767,7 +2767,7 @@ __metadata:
   dependencies:
     "@lavamoat/allow-scripts": ^2.1.0
     "@metamask/auto-changelog": ^3.0.0
-    "@metamask/browser-passworder": ^4.0.1
+    "@metamask/browser-passworder": ^4.0.2
     "@metamask/eslint-config": ^10.0.0
     "@metamask/eslint-config-jest": ^10.0.0
     "@metamask/eslint-config-nodejs": ^10.0.0


### PR DESCRIPTION
The version range for `@metamask/browser-passworder` has been updated to set `v4.0.2` as the minimum version. v4.0.0 and v4.0.1 included an unintentional breaking change that was fixed in v4.0.2.