### PR TITLE
fix keeping the wallet unlocked on sw restart after onboarding

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ class KeyringController extends EventEmitter {
 
     // This option allows the controller to cache an exported key
     // for use in decrypting and encrypting data without password
+
     this.cacheEncryptionKey = Boolean(opts.cacheEncryptionKey);
   }
 
@@ -599,8 +600,12 @@ class KeyringController extends EventEmitter {
     // Not calling _updateMemStoreKeyrings results in the wrong account being selected
     // in the extension.
     await this._updateMemStoreKeyrings();
+
     if (newEncryptionKey) {
-      this.memStore.updateState({ encryptionKey: newEncryptionKey });
+      this.memStore.updateState({
+        encryptionKey: newEncryptionKey,
+        encryptionSalt: JSON.parse(vault).salt,
+      });
     }
 
     return true;
@@ -921,4 +926,5 @@ function keyringBuilderFactory(Keyring) {
 module.exports = {
   KeyringController,
   keyringBuilderFactory,
+  KEYRINGS_TYPE_MAP,
 };

--- a/index.js
+++ b/index.js
@@ -57,7 +57,6 @@ class KeyringController extends EventEmitter {
 
     // This option allows the controller to cache an exported key
     // for use in decrypting and encrypting data without password
-
     this.cacheEncryptionKey = Boolean(opts.cacheEncryptionKey);
   }
 
@@ -926,5 +925,4 @@ function keyringBuilderFactory(Keyring) {
 module.exports = {
   KeyringController,
   keyringBuilderFactory,
-  KEYRINGS_TYPE_MAP,
 };

--- a/test/index.js
+++ b/test/index.js
@@ -10,7 +10,6 @@ const {
   PASSWORD,
   MOCK_HARDCODED_KEY,
   MOCK_HEX,
-  MOCK_SALT,
 } = require('./lib/mock-encryptor');
 const { KeyringMockWithInit } = require('./lib/mock-keyring');
 
@@ -154,32 +153,8 @@ describe('KeyringController', function () {
 
       it('should save an up to date encryption salt to the `memStore` when `password` is set through `createNewVaultAndKeychain`', async function () {
         keyringController.cacheEncryptionKey = true;
-        const vaultEncryptionKey = '🔑';
-        const vaultEncryptionSalt = MOCK_HEX;
-        const vault = JSON.stringify({ salt: vaultEncryptionSalt });
-        keyringController.store.updateState({ vault });
 
         await keyringController.createNewVaultAndKeychain(PASSWORD);
-
-        expect(keyringController.memStore.getState().encryptionKey).toBe(
-          MOCK_HARDCODED_KEY,
-        );
-        expect(keyringController.memStore.getState().encryptionSalt).toBe(
-          MOCK_HEX,
-        );
-
-        await keyringController.unlockKeyrings(
-          undefined,
-          vaultEncryptionKey,
-          vaultEncryptionSalt,
-        );
-
-        expect(keyringController.memStore.getState().encryptionKey).toBe(
-          vaultEncryptionKey,
-        );
-        expect(keyringController.memStore.getState().encryptionSalt).toBe(
-          vaultEncryptionSalt,
-        );
 
         const response = await keyringController.persistAllKeyrings();
 
@@ -194,32 +169,8 @@ describe('KeyringController', function () {
 
       it('should save an up to date encryption salt to the `memStore` when `password` is set through `submitPassword`', async function () {
         keyringController.cacheEncryptionKey = true;
-        const vaultEncryptionKey = '🔑';
-        const vaultEncryptionSalt = MOCK_HEX;
-        const vault = JSON.stringify({ salt: vaultEncryptionSalt });
-        keyringController.store.updateState({ vault });
 
         await keyringController.submitPassword(PASSWORD);
-
-        expect(keyringController.memStore.getState().encryptionKey).toBe(
-          MOCK_ENCRYPTION_KEY,
-        );
-        expect(keyringController.memStore.getState().encryptionSalt).toBe(
-          MOCK_SALT,
-        );
-
-        await keyringController.unlockKeyrings(
-          undefined,
-          vaultEncryptionKey,
-          vaultEncryptionSalt,
-        );
-
-        expect(keyringController.memStore.getState().encryptionKey).toBe(
-          vaultEncryptionKey,
-        );
-        expect(keyringController.memStore.getState().encryptionSalt).toBe(
-          vaultEncryptionSalt,
-        );
 
         const response = await keyringController.persistAllKeyrings();
 

--- a/test/index.js
+++ b/test/index.js
@@ -113,7 +113,7 @@ describe('KeyringController', function () {
       expect(keyrings).toHaveLength(2);
     });
 
-    describe('on a manifest v3 build', function () {
+    describe(`when 'cacheEncryptionKey' is enabled`, function () {
       it('should save up to date encryption salt to the memStore', async function () {
         keyringController.cacheEncryptionKey = true;
         const vaultEncryptionKey = '🔑';

--- a/test/index.js
+++ b/test/index.js
@@ -4,11 +4,7 @@ const { strict: assert } = require('assert');
 const Wallet = require('ethereumjs-wallet').default;
 const sinon = require('sinon');
 
-const {
-  KeyringController,
-  keyringBuilderFactory,
-  KEYRINGS_TYPE_MAP,
-} = require('..');
+const { KeyringController, keyringBuilderFactory } = require('..');
 const {
   mockEncryptor,
   PASSWORD,

--- a/test/index.js
+++ b/test/index.js
@@ -116,6 +116,7 @@ describe('KeyringController', function () {
 
     describe('when `cacheEncryptionKey` is enabled', function () {
       it('should save an up to date encryption salt to the `memStore` when `password` is unset and `encryptionKey` is set', async function () {
+        keyringController.password = undefined;
         keyringController.cacheEncryptionKey = true;
         const vaultEncryptionKey = '🔑';
         const vaultEncryptionSalt = '🧂';
@@ -144,10 +145,10 @@ describe('KeyringController', function () {
 
         expect(response).toBe(true);
         expect(keyringController.memStore.getState().encryptionKey).toBe(
-          MOCK_HARDCODED_KEY,
+          vaultEncryptionKey,
         );
         expect(keyringController.memStore.getState().encryptionSalt).toBe(
-          MOCK_HEX,
+          vaultEncryptionSalt,
         );
       });
 

--- a/test/lib/mock-encryptor.js
+++ b/test/lib/mock-encryptor.js
@@ -8,11 +8,12 @@ const MOCK_ENCRYPTION_DATA = `{"data":"2fOOPRKClNrisB+tmqIcETyZvDuL2iIR1Hr1nO7XZ
 
 const INVALID_PASSWORD_ERROR = 'Incorrect password.';
 
+const MOCK_HARDCODED_KEY = 'key';
 const MOCK_HEX = '0xabcdef0123456789';
 const MOCK_KEY = Buffer.alloc(32);
 let cacheVal;
 
-module.exports = {
+const mockEncryptor = {
   encrypt: sinon.stub().callsFake(function (_password, dataObj) {
     cacheVal = dataObj;
 
@@ -22,7 +23,10 @@ module.exports = {
   encryptWithDetail: sinon.stub().callsFake(function (_password, dataObj) {
     cacheVal = dataObj;
 
-    return Promise.resolve({ vault: MOCK_HEX, exportedKeyString: '' });
+    return Promise.resolve({
+      vault: JSON.stringify({ salt: MOCK_HEX }),
+      exportedKeyString: MOCK_HARDCODED_KEY,
+    });
   }),
 
   async decrypt(_password, _text) {
@@ -81,3 +85,5 @@ module.exports = {
     return 'WHADDASALT!';
   },
 };
+
+module.exports = { mockEncryptor, PASSWORD, MOCK_HARDCODED_KEY, MOCK_HEX };

--- a/test/lib/mock-encryptor.js
+++ b/test/lib/mock-encryptor.js
@@ -1,8 +1,13 @@
 const sinon = require('sinon');
 
 const PASSWORD = 'password123';
-const MOCK_ENCRYPTION_KEY =
-  '{"alg":"A256GCM","ext":true,"k":"wYmxkxOOFBDP6F6VuuYFcRt_Po-tSLFHCWVolsHs4VI","key_ops":["encrypt","decrypt"],"kty":"oct"}';
+const MOCK_ENCRYPTION_KEY = JSON.stringify({
+  alg: 'A256GCM',
+  ext: true,
+  k: 'wYmxkxOOFBDP6F6VuuYFcRt_Po-tSLFHCWVolsHs4VI',
+  key_ops: ['encrypt', 'decrypt'],
+  kty: 'oct',
+});
 const MOCK_ENCRYPTION_SALT = 'HQ5sfhsb8XAQRJtD+UqcImT7Ve4n3YMagrh05YTOsjk=';
 const MOCK_ENCRYPTION_DATA = `{"data":"2fOOPRKClNrisB+tmqIcETyZvDuL2iIR1Hr1nO7XZHyMqVY1cDBetw2gY5C+cIo1qkpyv3bPp+4buUjp38VBsjbijM0F/FLOqWbcuKM9h9X0uwxsgsZ96uwcIf5I46NiMgoFlhppTTMZT0Nkocz+SnvHM0IgLsFan7JqBU++vSJvx2M1PDljZSunOsqyyL+DKmbYmM4umbouKV42dipUwrCvrQJmpiUZrSkpMJrPJk9ufDQO4CyIVo0qry3aNRdYFJ6rgSyq/k6rXMwGExCMHn8UlhNnAMuMKWPWR/ymK1bzNcNs4VU14iVjEXOZGPvD9cvqVe/VtcnIba6axNEEB4HWDOCdrDh5YNWwMlQVL7vSB2yOhPZByGhnEOloYsj2E5KEb9jFGskt7EKDEYNofr6t83G0c+B72VGYZeCvgtzXzgPwzIbhTtKkP+gdBmt2JNSYrTjLypT0q+v4C9BN1xWTxPmX6TTt0NzkI9pJxgN1VQAfSU9CyWTVpd4CBkgom2cSBsxZ2MNbdKF+qSWz3fQcmJ55hxM0EGJSt9+8eQOTuoJlBapRk4wdZKHR2jdKzPjSF2MAmyVD2kU51IKa/cVsckRFEes+m7dKyHRvlNwgT78W9tBDdZb5PSlfbZXnv8z5q1KtAj2lM2ogJ7brHBdevl4FISdTkObpwcUMcvACOOO0dj6CSYjSKr0ZJ2RLChVruZyPDxEhKGb/8Kv8trLOR3mck/et6d050/NugezycNk4nnzu5iP90gPbSzaqdZI=","iv":"qTGO1afGv3waHN9KoW34Eg==","salt":"${MOCK_ENCRYPTION_SALT}"}`;
 
@@ -10,6 +15,7 @@ const INVALID_PASSWORD_ERROR = 'Incorrect password.';
 
 const MOCK_HARDCODED_KEY = 'key';
 const MOCK_HEX = '0xabcdef0123456789';
+const MOCK_SALT = 'SALT';
 const MOCK_KEY = Buffer.alloc(32);
 let cacheVal;
 
@@ -51,7 +57,7 @@ const mockEncryptor = {
       ? {
           vault: cacheVal,
           exportedKeyString: MOCK_ENCRYPTION_KEY,
-          salt: 'SALT',
+          salt: MOCK_SALT,
         }
       : {};
     return Promise.resolve(result);
@@ -86,4 +92,11 @@ const mockEncryptor = {
   },
 };
 
-module.exports = { mockEncryptor, PASSWORD, MOCK_HARDCODED_KEY, MOCK_HEX };
+module.exports = {
+  mockEncryptor,
+  PASSWORD,
+  MOCK_HARDCODED_KEY,
+  MOCK_HEX,
+  MOCK_ENCRYPTION_KEY,
+  MOCK_SALT,
+};


### PR DESCRIPTION
## Explanation

We want to keep the wallet unlocked when a service worker restarts.

In `persistAllKeyrings`, when we're building for mv3 and want to cache the `encryptionKey` but a password was entered and a new `encryptionKey` has been generated, we want to save `encryptionSalt` alongside the new `encryptionKey` in the  keyring controller `memStore`.

This is so it can be [saved in storage](https://github.com/MetaMask/metamask-extension/blob/987daee85483c38ec9592a05fb8efe1f0e71eda7/app/scripts/metamask-controller.js#L4257) and then [retrieved](https://github.com/MetaMask/metamask-extension/blob/987daee85483c38ec9592a05fb8efe1f0e71eda7/app/scripts/metamask-controller.js#L2595) on the metamask controller for the extension.

Note that this PR only fixes the first time the service worker is restarted after a fresh wallet is loaded and the onboarding flow is complete. Unlocked wallet persistence for subsequent service worker restarts has been fixed on a [separate PR](https://github.com/MetaMask/metamask-extension/pull/17950) on the extension repository.

For context, this was [previously addressed](https://github.com/MetaMask/metamask-extension/pull/15558), but the wallet was still locked after a long enough waiting period after the service worker restarted. [Another PR](https://github.com/MetaMask/metamask-extension/pull/16559) has since been merged, making the wallet lock more immediately apparent.

## Manual Testing Steps

1. Build the extension wallet from develop

`git checkout develop && git pull && yarn && yarn:start:mv3`

2. Load the wallet in the browser and complete the onboarding flow

3. Terminate the service worker using `chrome://inspect/#service-workers`. 

4. The wallet should lock after a couple of seconds.

5. Add the changes on `index.js` on this PR to the corresponding file on the `node_modules` folder of the Metamask Extension.

6. Build the wallet again.

7. Load the wallet in the browser and complete the onboarding flow

8. Terminate the service worker using `chrome://inspect/#service-workers`. 

9. The wallet should remain unlocked.

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.


