### PR TITLE
[FIX] Property name `isUnlocked`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export type KeyringControllerState = {
 
   keyrings?: Keyring<Json>[];
 
-  vaultUnlock?: boolean;
+  isUnlocked?: boolean;
 
   encryptionKey?: string;
 


### PR DESCRIPTION
Change property name from `vaultUnlock` to `isUnlocked`. This was a change from the TS refactor that got merged unintentionally.