### PR TITLE
Bump `ts-jest`

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "prettier": "^2.8.1",
     "prettier-plugin-packagejson": "^2.3.0",
     "sinon": "^15.0.1",
-    "ts-jest": "^29.0.3",
+    "ts-jest": "^29.1.0",
     "ts-node": "^10.7.0",
     "typedoc": "^0.23.15",
     "typescript": "~5.0.2"

--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -1036,7 +1036,9 @@ class KeyringController extends EventEmitter {
 
     await keyring.deserialize(data);
 
+    // @ts-expect-error The method 'init' is not part of the current Keyring type
     if (keyring.init) {
+      // @ts-expect-error The method 'init' is not part of the current Keyring type
       await keyring.init();
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1440,7 +1440,7 @@ __metadata:
     prettier: ^2.8.1
     prettier-plugin-packagejson: ^2.3.0
     sinon: ^15.0.1
-    ts-jest: ^29.0.3
+    ts-jest: ^29.1.0
     ts-node: ^10.7.0
     typedoc: ^0.23.15
     typescript: ~5.0.2
@@ -7411,9 +7411,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-jest@npm:^29.0.3":
-  version: 29.0.5
-  resolution: "ts-jest@npm:29.0.5"
+"ts-jest@npm:^29.1.0":
+  version: 29.1.0
+  resolution: "ts-jest@npm:29.1.0"
   dependencies:
     bs-logger: 0.x
     fast-json-stable-stringify: 2.x
@@ -7428,7 +7428,7 @@ __metadata:
     "@jest/types": ^29.0.0
     babel-jest: ^29.0.0
     jest: ^29.0.0
-    typescript: ">=4.3"
+    typescript: ">=4.3 <6"
   peerDependenciesMeta:
     "@babel/core":
       optional: true
@@ -7440,7 +7440,7 @@ __metadata:
       optional: true
   bin:
     ts-jest: cli.js
-  checksum: f60f129c2287f4c963d9ee2677132496c5c5a5d39c27ad234199a1140c26318a7d5bda34890ab0e30636ec42a8de28f84487c09e9dcec639c9c67812b3a38373
+  checksum: 535dc42ad523cbe1e387701fb2e448518419b515c082f09b25411f0b3dd0b854cf3e8141c316d6f4b99883aeb4a4f94159cbb1edfb06d7f77ea6229fadb2e1bf
   languageName: node
   linkType: hard
 
@@ -7589,22 +7589,22 @@ __metadata:
   linkType: hard
 
 "typescript@npm:~5.0.2":
-  version: 5.0.2
-  resolution: "typescript@npm:5.0.2"
+  version: 5.0.4
+  resolution: "typescript@npm:5.0.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: bef1dcd166acfc6934b2ec4d72f93edb8961a5fab36b8dd2aaf6f4f4cd5c0210f2e0850aef4724f3b4913d5aef203a94a28ded731b370880c8bcff7e4ff91fc1
+  checksum: 82b94da3f4604a8946da585f7d6c3025fff8410779e5bde2855ab130d05e4fd08938b9e593b6ebed165bda6ad9292b230984f10952cf82f0a0ca07bbeaa08172
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@~5.0.2#~builtin<compat/typescript>":
-  version: 5.0.2
-  resolution: "typescript@patch:typescript@npm%3A5.0.2#~builtin<compat/typescript>::version=5.0.2&hash=701156"
+  version: 5.0.4
+  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=701156"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: bdbf3d0aac0d6cf010fbe0536753dc19f278eb4aba88140dcd25487dfe1c56ca8b33abc0dcd42078790a939b08ebc4046f3e9bb961d77d3d2c3cfa9829da4d53
+  checksum: 6a1fe9a77bb9c5176ead919cc4a1499ee63e46b4e05bf667079f11bf3a8f7887f135aa72460a4c3b016e6e6bb65a822cb8689a6d86cbfe92d22cc9f501f09213
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
There is a false positive in the current CI caused by using `TypeScript v.5.0.2` and `ts-jest  v29.0.3`. This development updates it to the required version and ignores the error in the meanwhile.

![Screenshot 2023-04-19 at 13 45 21](https://user-images.githubusercontent.com/17601467/233157439-686be11c-4893-4e95-9c48-983faf33a83e.png)

The PR https://github.com/MetaMask/utils/pull/99 should solve the root cause of the TS error.
