### PR TITLE
Dispose or destroy keyrings on reference drop

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 70.37,
-      functions: 92.72,
-      lines: 90.72,
-      statements: 90.93,
+      branches: 73.03,
+      functions: 92.85,
+      lines: 90.93,
+      statements: 91.14,
     },
   },
   preset: 'ts-jest',

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 73.03,
+      branches: 70.45,
       functions: 92.85,
-      lines: 90.93,
-      statements: 91.14,
+      lines: 90.57,
+      statements: 90.78,
     },
   },
   preset: 'ts-jest',

--- a/src/KeyringController.test.ts
+++ b/src/KeyringController.test.ts
@@ -562,10 +562,11 @@ describe('KeyringController', () => {
       const dispose = sinon.spy();
       HdKeyring.prototype.destroy = destroy;
       HdKeyring.prototype.dispose = dispose;
-      const accountToRemove =
-        await keyringController.keyrings[0]?.getAccounts();
+      const accountToRemove = (
+        await keyringController.keyrings[0]?.getAccounts()
+      )?.[0];
 
-      await keyringController.removeAccount(accountToRemove?.[0] as Hex);
+      await keyringController.removeAccount(accountToRemove as Hex);
 
       expect(destroy.calledOnce).toBe(true);
       expect(dispose.calledOnce).toBe(true);

--- a/src/KeyringController.test.ts
+++ b/src/KeyringController.test.ts
@@ -78,6 +78,19 @@ describe('KeyringController', () => {
 
       expect(lockSpy.calledOnce).toBe(true);
     });
+
+    it('calls keyring optional destroy or dispose functions', async () => {
+      const destroy = sinon.spy();
+      const dispose = sinon.spy();
+
+      HdKeyring.prototype.destroy = destroy;
+      HdKeyring.prototype.dispose = dispose;
+
+      await keyringController.setLocked();
+
+      expect(destroy.calledOnce).toBe(true);
+      expect(dispose.calledOnce).toBe(true);
+    });
   });
 
   describe('submitPassword', () => {
@@ -542,6 +555,20 @@ describe('KeyringController', () => {
       // Check that the previous keyring with only one account
       // was also removed after removing the account
       expect(keyringController.keyrings).toHaveLength(1);
+    });
+
+    it('calls keyring destroy or dispose if available', async () => {
+      const destroy = sinon.spy();
+      const dispose = sinon.spy();
+      HdKeyring.prototype.destroy = destroy;
+      HdKeyring.prototype.dispose = dispose;
+      const accountToRemove =
+        await keyringController.keyrings[0]?.getAccounts();
+
+      await keyringController.removeAccount(accountToRemove?.[0] as Hex);
+
+      expect(destroy.calledOnce).toBe(true);
+      expect(dispose.calledOnce).toBe(true);
     });
 
     it('does not remove the keyring if there are accounts remaining after removing one from the keyring', async () => {

--- a/src/KeyringController.test.ts
+++ b/src/KeyringController.test.ts
@@ -79,17 +79,13 @@ describe('KeyringController', () => {
       expect(lockSpy.calledOnce).toBe(true);
     });
 
-    it('calls keyring optional destroy or dispose functions', async () => {
-      const destroy = sinon.spy();
-      const dispose = sinon.spy();
-
-      HdKeyring.prototype.destroy = destroy;
-      HdKeyring.prototype.dispose = dispose;
+    it('calls keyring optional destroy function', async () => {
+      const destroy = sinon.spy(KeyringMockWithInit.prototype, 'destroy');
+      await keyringController.addNewKeyring('Keyring Mock With Init');
 
       await keyringController.setLocked();
 
       expect(destroy.calledOnce).toBe(true);
-      expect(dispose.calledOnce).toBe(true);
     });
   });
 
@@ -557,19 +553,16 @@ describe('KeyringController', () => {
       expect(keyringController.keyrings).toHaveLength(1);
     });
 
-    it('calls keyring destroy or dispose if available', async () => {
-      const destroy = sinon.spy();
-      const dispose = sinon.spy();
-      HdKeyring.prototype.destroy = destroy;
-      HdKeyring.prototype.dispose = dispose;
-      const accountToRemove = (
-        await keyringController.keyrings[0]?.getAccounts()
-      )?.[0];
+    it('calls keyring optional destroy function', async () => {
+      const destroy = sinon.spy(KeyringMockWithInit.prototype, 'destroy');
+      const keyring = await keyringController.addNewKeyring(
+        'Keyring Mock With Init',
+      );
+      sinon.stub(keyringController, 'getKeyringForAccount').resolves(keyring);
 
-      await keyringController.removeAccount(accountToRemove as Hex);
+      await keyringController.removeAccount('0x0');
 
       expect(destroy.calledOnce).toBe(true);
-      expect(dispose.calledOnce).toBe(true);
     });
 
     it('does not remove the keyring if there are accounts remaining after removing one from the keyring', async () => {

--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -990,8 +990,11 @@ class KeyringController extends EventEmitter {
    */
   #clearKeyrings() {
     // clear keyrings from memory
-    for (const keyring of this.keyrings) {
-      this.#disposeKeyring(keyring);
+    while (this.keyrings.length > 0) {
+      const keyring = this.keyrings.pop();
+      if (keyring) {
+        this.#disposeKeyring(keyring);
+      }
     }
     this.memStore.updateState({
       keyrings: [],

--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -990,11 +990,8 @@ class KeyringController extends EventEmitter {
    */
   #clearKeyrings() {
     // clear keyrings from memory
-    while (this.keyrings.length > 0) {
-      const keyring = this.keyrings.pop();
-      if (keyring) {
-        this.#disposeKeyring(keyring);
-      }
+    for (const keyring of this.keyrings) {
+      this.#disposeKeyring(keyring);
     }
     this.memStore.updateState({
       keyrings: [],

--- a/src/test/keyring.mock.ts
+++ b/src/test/keyring.mock.ts
@@ -33,6 +33,14 @@ class KeyringMockWithInit implements Keyring<Json> {
   async deserialize(_: any) {
     return Promise.resolve();
   }
+
+  async removeAccount(_: any) {
+    return Promise.resolve();
+  }
+
+  async destroy() {
+    return Promise.resolve();
+  }
 }
 
 export default KeyringMockWithInit;


### PR DESCRIPTION
## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are you introducing a breaking change  (renaming, removing, or changing a part of a public-facing interface)?
-->

This PR calls the optional methods `destroy` and `dispose` on keyrings that support them (Trezor and Ledger) whenever the reference to the keyring is dropped: when locked and when the last account from a keyring is removed. 

To avoid introducing one of the two (Trezor or Ledger) keyrings just to be used on tests, I extended the HDKeyring prototype to also present a `destroy` and a `dispose` method, in order to be spied on.

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

- **CHANGED**: When defined, `Keyring.dispose` or `Keyring.destroy` methods are called on any keyring reference drop

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

* Fixes [#1388](https://github.com/MetaMask/core/issues/1388)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
