### PR TITLE
Update utils package and rename dispose fn

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 70.45,
+      branches: 72.09,
       functions: 92.85,
-      lines: 90.57,
-      statements: 90.78,
+      lines: 90.81,
+      statements: 91.02,
     },
   },
   preset: 'ts-jest',

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@metamask/eth-hd-keyring": "^6.0.0",
     "@metamask/eth-sig-util": "^6.0.0",
     "@metamask/eth-simple-keyring": "^5.0.0",
-    "@metamask/utils": "^5.0.0",
+    "@metamask/utils": "^6.1.0",
     "obs-store": "^4.0.3"
   },
   "devDependencies": {

--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -641,7 +641,7 @@ class KeyringController extends EventEmitter {
         if (accounts.length > 0) {
           validKeyrings.push(keyring);
         } else {
-          await this.#disposeKeyring(keyring);
+          await this.#destroyKeyring(keyring);
         }
       }),
     );
@@ -991,7 +991,7 @@ class KeyringController extends EventEmitter {
   async #clearKeyrings() {
     // clear keyrings from memory
     for (const keyring of this.keyrings) {
-      await this.#disposeKeyring(keyring);
+      await this.#destroyKeyring(keyring);
     }
     this.keyrings = [];
     this.memStore.updateState({
@@ -1000,23 +1000,16 @@ class KeyringController extends EventEmitter {
   }
 
   /**
-   * Dispose Keyring
+   * Destroy Keyring
    *
-   * The Trezor Keyring has a method called `dispose` that removes the
-   * iframe from the DOM. The Ledger Keyring has a method called `destroy`
-   * that clears the keyring event listeners. This method checks if the provided
-   * keyring has either of these methods and calls them if they exist.
+   * Some keyrings support a method called `destroy`, that destroys the
+   * keyring along with removing all its event listeners and, in some cases,
+   * clears the keyring bridge iframe from the DOM.
    *
-   * @param keyring - The keyring to dispose or destroy.
+   * @param keyring - The keyring to destroy.
    */
-  async #disposeKeyring(keyring: Keyring<Json>) {
-    if ('dispose' in keyring && typeof keyring.dispose === 'function') {
-      await keyring.dispose();
-    }
-
-    if ('destroy' in keyring && typeof keyring.destroy === 'function') {
-      await keyring.destroy();
-    }
+  async #destroyKeyring(keyring: Keyring<Json>) {
+    await keyring.destroy?.();
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1074,7 +1074,7 @@ __metadata:
     "@metamask/eth-hd-keyring": ^6.0.0
     "@metamask/eth-sig-util": ^6.0.0
     "@metamask/eth-simple-keyring": ^5.0.0
-    "@metamask/utils": ^5.0.0
+    "@metamask/utils": ^6.1.0
     "@types/jest": ^29.4.0
     "@types/sinon": ^10.0.13
     "@typescript-eslint/eslint-plugin": ^5.55.0
@@ -1152,16 +1152,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^5.0.0":
-  version: 5.0.2
-  resolution: "@metamask/utils@npm:5.0.2"
+"@metamask/utils@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@metamask/utils@npm:6.1.0"
   dependencies:
     "@ethereumjs/tx": ^4.1.2
     "@types/debug": ^4.1.7
     debug: ^4.3.4
     semver: ^7.3.8
     superstruct: ^1.0.3
-  checksum: eca82e42911b2840deb4f32f0f215c5ffd14d22d68afbbe92d3180e920e509e310777b15eab29def3448f3535b66596ceb4c23666ec846adacc8e1bb093ff882
+  checksum: d4eac3ce3c08674b8e9ef838d1661a5025690c6f266c26ebdb8e8d0da11fce786e54c326b5d9c6d33b262f37e7057e31d6545a3715613bd0a5bfa10e7755643a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This PR pulls the latest version of `@metamask/utils`, which also includes an updated `Keyring` type with an optional `destroy` method: this allows us to remove some type narrowing and the ambiguity between `dispose` and `destroy` methods. 

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are you introducing a breaking change  (renaming, removing, or changing a part of a public-facing interface)?
-->

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

- **CHANGED**: `dispose` optional method is not called anymore when destroying a keyring

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
