### PR TITLE
Update `@metamask/eth-sig-util` to `^6`

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@ethereumjs/tx": "^4.1.1",
     "@metamask/browser-passworder": "^4.1.0",
     "@metamask/eth-hd-keyring": "^6.0.0",
-    "@metamask/eth-sig-util": "^5.1.0",
+    "@metamask/eth-sig-util": "^6.0.0",
     "@metamask/eth-simple-keyring": "^5.0.0",
     "@metamask/utils": "^5.0.0",
     "obs-store": "^4.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1072,7 +1072,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^11.1.0
     "@metamask/eslint-config-typescript": ^11.1.0
     "@metamask/eth-hd-keyring": ^6.0.0
-    "@metamask/eth-sig-util": ^5.1.0
+    "@metamask/eth-sig-util": ^6.0.0
     "@metamask/eth-simple-keyring": ^5.0.0
     "@metamask/utils": ^5.0.0
     "@types/jest": ^29.4.0
@@ -1102,7 +1102,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/eth-sig-util@npm:^5.0.1, @metamask/eth-sig-util@npm:^5.0.2, @metamask/eth-sig-util@npm:^5.1.0":
+"@metamask/eth-sig-util@npm:^5.0.1, @metamask/eth-sig-util@npm:^5.0.2":
   version: 5.1.0
   resolution: "@metamask/eth-sig-util@npm:5.1.0"
   dependencies:
@@ -1113,6 +1113,20 @@ __metadata:
     tweetnacl: ^1.0.3
     tweetnacl-util: ^0.15.1
   checksum: c639e3bf91625faeb0230a6314f0b2d05e8f5e2989542d3e0eed1d21b7b286e1860f68629870fd7e568c1a599b3993c4210403fb4c84a625fb1e75ef676eab4f
+  languageName: node
+  linkType: hard
+
+"@metamask/eth-sig-util@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@metamask/eth-sig-util@npm:6.0.0"
+  dependencies:
+    "@ethereumjs/util": ^8.0.6
+    bn.js: ^4.12.0
+    ethereum-cryptography: ^2.0.0
+    ethjs-util: ^0.1.6
+    tweetnacl: ^1.0.3
+    tweetnacl-util: ^0.15.1
+  checksum: 76c173faed20d0d896561dbf3eb4ec3173e33288bf8844919643fd3e9fb6bc78f1ba8bd8a82252f4d13526ded4cc1aee27ae78f5b32642d9f97ef15fa230a12e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are you introducing a breaking change  (renaming, removing, or changing a part of a public-facing interface)?
-->

This PR updates `@metamask/eth-sig-util` package to `^6`, which includes a change on the `normalize` function that affects how empty strings and `0` inputs are treated, and since `@metamask/eth-keyring-controller` normalizes data passed to `signPersonalMessage` since v11, I think this change should be breaking also for `@metamask/eth-keyring-controller`.

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

- **BREAKING**: `signPersonalMessage` now normalizes `msgParams.data` in a different way for `0` and empty strings inputs. 
    - `0` will be normalized to `0x00` and empty strings to `0x` 

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
* Related to [#1315](https://github.com/MetaMask/core/issues/1315)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
