### PR TITLE
Fix `@metamask/eth-sig-util` types

### DIFF
--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -334,7 +334,9 @@ class KeyringController extends EventEmitter {
       return res.concat(arr);
     }, []);
 
-    return addresses.map(normalizeToHex);
+    // Cast to `Hex[]` here is safe here because `addresses` has no nullish
+    // values, and `normalizeToHex` returns `Hex` unless given a nullish value
+    return addresses.map(normalizeToHex) as Hex[];
   }
 
   /**
@@ -515,7 +517,9 @@ class KeyringController extends EventEmitter {
     },
     opts: Record<string, unknown> = { version: 'V1' },
   ): Promise<Bytes> {
-    const address = normalizeToHex(msgParams.from);
+    // Cast to `Hex` here is safe here because `msgParams.from` is not nullish.
+    // `normalizeToHex` returns `Hex` unless given a nullish value.
+    const address = normalizeToHex(msgParams.from) as Hex;
     const keyring = await this.getKeyringForAccount(address);
     if (!keyring.signTypedData) {
       throw new Error(KeyringControllerError.UnsupportedSignTypedMessage);
@@ -697,7 +701,9 @@ class KeyringController extends EventEmitter {
    * @returns The keyring of the account, if it exists.
    */
   async getKeyringForAccount(address: string): Promise<Keyring<Json>> {
-    const hexed = normalizeToHex(address);
+    // Cast to `Hex` here is safe here because `address` is not nullish.
+    // `normalizeToHex` returns `Hex` unless given a nullish value.
+    const hexed = normalizeToHex(address) as Hex;
 
     const candidates = await Promise.all(
       this.keyrings.map(async (keyring) => {
@@ -1086,7 +1092,9 @@ async function displayForKeyring(
 
   return {
     type: keyring.type,
-    accounts: accounts.map(normalizeToHex),
+    // Cast to `Hex[]` here is safe here because `addresses` has no nullish
+    // values, and `normalizeToHex` returns `Hex` unless given a nullish value
+    accounts: accounts.map(normalizeToHex) as Hex[],
   };
 }
 

--- a/src/types/@metamask/eth-sig-util.d.ts
+++ b/src/types/@metamask/eth-sig-util.d.ts
@@ -1,2 +1,0 @@
-// eslint-disable-next-line import/unambiguous
-declare module '@metamask/eth-sig-util';


### PR DESCRIPTION
## Description

The types for the package `@metamask/eth-sig-util` were being overwritten by a local type declaration. That has been removed, and all type errors have been resolved.

All of the type errors were related to `normalize` returning `undefined` if given a nullish input. We never pass it a nullish input, but TypeScript wasn't able to infer that, so that issue was addressed with type casts. This isn't ideal, but it's temporary. Once we finish migrating all Keyrings to the new Keyring interface, we won't need to normalize addresses anymore at all.

## Changes

None

## References

I was attempting to fix type errors in this package that were discovered while reviewing https://github.com/MetaMask/core/pull/1441. I was unable to use additional types from `@metamask/eth-sig-util` due to the problem fixed by this PR.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
