### PR TITLE
Narrow return type of `signTypedMessage` and encryption methods

### DIFF
--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -7,7 +7,6 @@ import { remove0x, isValidHexAddress } from '@metamask/utils';
 import type {
   Hex,
   Json,
-  Bytes,
   Keyring,
   KeyringClass,
   Eip1024EncryptedData,
@@ -467,7 +466,7 @@ class KeyringController extends EventEmitter {
   async getEncryptionPublicKey(
     address: string,
     opts: Record<string, unknown> = {},
-  ): Promise<Bytes> {
+  ): Promise<string> {
     const normalizedAddress = normalizeToHex(address) as Hex;
     const keyring = await this.getKeyringForAccount(address);
     if (!keyring.getEncryptionPublicKey) {
@@ -490,7 +489,7 @@ class KeyringController extends EventEmitter {
   async decryptMessage(msgParams: {
     from: string;
     data: Eip1024EncryptedData;
-  }): Promise<Bytes> {
+  }): Promise<string> {
     const address = normalizeToHex(msgParams.from) as Hex;
     const keyring = await this.getKeyringForAccount(address);
     if (!keyring.decryptMessage) {

--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -516,7 +516,7 @@ class KeyringController extends EventEmitter {
       data: Record<string, unknown>[];
     },
     opts: Record<string, unknown> = { version: 'V1' },
-  ): Promise<Bytes> {
+  ): Promise<string> {
     // Cast to `Hex` here is safe here because `msgParams.from` is not nullish.
     // `normalizeToHex` returns `Hex` unless given a nullish value.
     const address = normalizeToHex(msgParams.from) as Hex;


### PR DESCRIPTION
## Description

The methods `signTypedMessage`, `getEncryptionPublicKey`, and `decryptMessage` always return a string, but the declared return type was `Bytes` (which is a type union of `string` along with other things). This made the methods more difficult to use, as callers had to handle the other `Bytes` types as return values as well. 

The methods have been updated to use `string` as the return type.

## Changes

- Changed: The methods `signTypedMessage`, `getEncryptionPublicKey`, and `decryptMessage`  now return `string` rather than `Bytes`
  - This is non-breaking because the `Bytes` type includes `string`

## References

Helps to unblock https://github.com/MetaMask/core/pull/1441

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
