### PR TITLE
Fix `signTypedMessage` parameter types

### DIFF
--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -512,7 +512,7 @@ class KeyringController extends EventEmitter {
   async signTypedMessage(
     msgParams: {
       from: string;
-      data: Record<string, unknown>[];
+      data: Record<string, unknown> | Record<string, unknown>[];
     },
     opts: Record<string, unknown> = { version: 'V1' },
   ): Promise<string> {


### PR DESCRIPTION
## Description

The `signTypedMessage` parameter types accepted the data to sign as an array. This works with `signTypedData_v1`, but is incompatible with later versions.

The signature has been updated to accept data as either an array or an object. Additionally, tests have been added to cover all three supported versions of `signTypedData`.

## Changes

- Fixed: `signTypedMessage` now accepts data either as an array or an object
  - This was a mistake in the original type definition - it always supported both in practice.

## References

Helps to unblock https://github.com/MetaMask/core/pull/1441

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
