### PR TITLE
Restore compatibility with QR Keyring

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 72.09,
+      branches: 72.41,
       functions: 92.85,
-      lines: 90.81,
-      statements: 91.02,
+      lines: 90.87,
+      statements: 91.08,
     },
   },
   preset: 'ts-jest',

--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -4,7 +4,7 @@ import HDKeyring from '@metamask/eth-hd-keyring';
 import { normalize as normalizeToHex } from '@metamask/eth-sig-util';
 import SimpleKeyring from '@metamask/eth-simple-keyring';
 import { ObservableStore } from '@metamask/obs-store';
-import { remove0x, isValidHexAddress } from '@metamask/utils';
+import { remove0x, isValidHexAddress, isObject } from '@metamask/utils';
 import type {
   Hex,
   Json,
@@ -586,11 +586,14 @@ class KeyringController extends EventEmitter {
    */
   async addNewKeyring(
     type: string,
-    opts: Record<string, unknown> = {},
+    opts?: Record<string, unknown>,
   ): Promise<Keyring<Json>> {
     let keyring: Keyring<Json>;
     switch (type) {
       case KeyringType.Simple:
+        if (!isObject(opts)) {
+          throw new Error('Private keys missing');
+        }
         keyring = await this.#newKeyring(type, opts.privateKeys);
         break;
       default:
@@ -602,7 +605,7 @@ class KeyringController extends EventEmitter {
       throw new Error(KeyringControllerError.NoKeyring);
     }
 
-    if (!opts.mnemonic && type === KeyringType.HD) {
+    if (type === KeyringType.HD && (!isObject(opts) || !opts.mnemonic)) {
       if (!keyring.generateRandomMnemonic) {
         throw new Error(
           KeyringControllerError.UnsupportedGenerateRandomMnemonic,


### PR DESCRIPTION
## Description

The `KeyringController` method `addNewKeyring` was changed in v11 to initialize the keyring options to an empty object. These options are passed to the `deserialize` method of the keyring. This broke compatibility with the QR keyring because its `deserialize` method does not expect to be passed an empty object.

The `KeyringController` has been updated to no longer initialize the `addNewKeyring` options to an empty object. It should now work the same as it did prior to v11. The one functional difference is that it now throws an error when `addNewKeyring` is used to add a simple keyring without supplying any private keys, however that path would have already thrown an error.

## Changes

- Fixed: Fix `addNewKeyring` incompatbility when no options are provided
  - The `addNewKeyring` method stopped working with certain keyrings (e.g. the QR keyring) in v11 when called with no options. 

## References

This bug was introduced before and fixed in the past, e.g. https://github.com/MetaMask/KeyringController/pull/136

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
