### PR TITLE
fix: await account removal

### DIFF
--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -301,7 +301,11 @@ class KeyringController extends EventEmitter {
     if (!keyring.removeAccount) {
       throw new Error(KeyringControllerError.UnsupportedRemoveAccount);
     }
-    keyring.removeAccount(address);
+
+    // The `removeAccount` method of snaps keyring is async. We have to update
+    // the interface of the other keyrings to be async as well.
+    // eslint-disable-next-line @typescript-eslint/await-thenable
+    await keyring.removeAccount(address);
     this.emit('removedAccount', address);
 
     const accounts = await keyring.getAccounts();


### PR DESCRIPTION
## Description

The `removeAccount` method of some keyrings is async (e.g. `SnapKeyring`), so this PR makes the `KeyringController` await the account removal.

In the future, we must make sure that all keyrings implement the same interface.