### PR TITLE
Add `encryptor` types

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 79.61,
+      branches: 79.41,
       functions: 93.22,
-      lines: 91.53,
-      statements: 91.71,
+      lines: 91.5,
+      statements: 91.69,
     },
   },
   preset: 'ts-jest',

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 76.63,
-      functions: 93.65,
-      lines: 90.76,
-      statements: 90.96,
+      branches: 79.8,
+      functions: 93.1,
+      lines: 91.63,
+      statements: 91.82,
     },
   },
   preset: 'ts-jest',

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 77.47,
+      branches: 76.63,
       functions: 93.65,
-      lines: 90.96,
-      statements: 91.15,
+      lines: 90.76,
+      statements: 90.96,
     },
   },
   preset: 'ts-jest',

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 79.8,
-      functions: 93.1,
-      lines: 91.63,
-      statements: 91.82,
+      branches: 79.61,
+      functions: 93.22,
+      lines: 91.53,
+      statements: 91.71,
     },
   },
   preset: 'ts-jest',

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 71.42,
-      functions: 92.85,
-      lines: 90.68,
-      statements: 90.9,
+      branches: 77.47,
+      functions: 93.65,
+      lines: 90.96,
+      statements: 91.15,
     },
   },
   preset: 'ts-jest',

--- a/package.json
+++ b/package.json
@@ -44,12 +44,12 @@
   },
   "dependencies": {
     "@ethereumjs/tx": "^4.2.0",
-    "@metamask/browser-passworder": "^4.1.0",
+    "@metamask/browser-passworder": "^4.2.0",
     "@metamask/eth-hd-keyring": "^7.0.1",
     "@metamask/eth-sig-util": "^7.0.0",
     "@metamask/eth-simple-keyring": "^6.0.1",
     "@metamask/obs-store": "^8.1.0",
-    "@metamask/utils": "^8.1.0"
+    "@metamask/utils": "^8.2.0"
   },
   "devDependencies": {
     "@ethereumjs/wallet": "^2.0.0",

--- a/src/KeyringController.test.ts
+++ b/src/KeyringController.test.ts
@@ -15,7 +15,7 @@ import {
   MOCK_HARDCODED_KEY,
   MOCK_ENCRYPTION_SALT,
 } from './test';
-import type { KeyEncryptor, KeyringControllerArgs } from './types';
+import type { ExportableKeyEncryptor, KeyringControllerArgs } from './types';
 
 const MOCK_ENCRYPTION_KEY =
   '{"alg":"A256GCM","ext":true,"k":"wYmxkxOOFBDP6F6VuuYFcRt_Po-tSLFHCWVolsHs4VI","key_ops":["encrypt","decrypt"],"kty":"oct"}';
@@ -856,7 +856,7 @@ describe('KeyringController', () => {
           );
           const updateVaultStub = sinon
             .stub(
-              keyringController.encryptor as KeyEncryptor,
+              keyringController.encryptor as ExportableKeyEncryptor,
               'updateVaultWithDetail',
             )
             .resolves({
@@ -1091,10 +1091,10 @@ describe('KeyringController', () => {
         },
       });
       const returnValue = await (
-        keyringController.encryptor as KeyEncryptor
+        keyringController.encryptor as ExportableKeyEncryptor
       ).decryptWithKey('', '');
       const decryptWithKeyStub = sinon.stub(
-        keyringController.encryptor as KeyEncryptor,
+        keyringController.encryptor as ExportableKeyEncryptor,
         'decryptWithKey',
       );
       decryptWithKeyStub.resolves(Promise.resolve(returnValue));

--- a/src/KeyringController.test.ts
+++ b/src/KeyringController.test.ts
@@ -88,6 +88,7 @@ describe('KeyringController', () => {
       it('should throw error if provided encryptor does not support key export', async () => {
         expect(
           () =>
+            // @ts-expect-error we want to bypass typechecks here.
             new KeyringController({
               cacheEncryptionKey: true,
               encryptor: {

--- a/src/KeyringController.test.ts
+++ b/src/KeyringController.test.ts
@@ -193,8 +193,8 @@ describe('KeyringController', () => {
 
       assert(keyringController.store.getState().vault, 'Vault is not set');
       expect(encryptSpy.calledOnce).toBe(true);
-      expect(encryptSpy.getCalls()?.[0]?.args[1]).toHaveLength(2);
-      expect(encryptSpy.getCalls()?.[0]?.args[1]).toContain(unsupportedKeyring);
+      expect(encryptSpy.getCalls()[0]?.args[1]).toHaveLength(2);
+      expect(encryptSpy.getCalls()[0]?.args[1]).toContain(unsupportedKeyring);
     });
 
     describe('when `cacheEncryptionKey` is enabled', () => {

--- a/src/KeyringController.test.ts
+++ b/src/KeyringController.test.ts
@@ -96,7 +96,7 @@ describe('KeyringController', () => {
                 encrypt: async (_pass: string, _obj: any) => 'decrypted',
               },
             }),
-        ).toThrow(KeyringControllerError.UnsupportedKeyDecryption);
+        ).toThrow(KeyringControllerError.UnsupportedEncryptionKeyExport);
       });
     });
   });
@@ -117,7 +117,7 @@ describe('KeyringController', () => {
       });
 
       expect(() => (keyringController.encryptor = encryptor)).toThrow(
-        KeyringControllerError.UnsupportedKeyDecryption,
+        KeyringControllerError.UnsupportedEncryptionKeyExport,
       );
     });
   });
@@ -138,7 +138,7 @@ describe('KeyringController', () => {
       });
 
       expect(() => (keyringController.cacheEncryptionKey = true)).toThrow(
-        KeyringControllerError.UnsupportedKeyDecryption,
+        KeyringControllerError.UnsupportedEncryptionKeyExport,
       );
     });
   });

--- a/src/KeyringController.test.ts
+++ b/src/KeyringController.test.ts
@@ -841,7 +841,7 @@ describe('KeyringController', () => {
 
     describe('with old vault format', () => {
       describe('with cacheEncryptionKey = true', () => {
-        it('should update the vault to new format', async () => {
+        it('should call persistAllKeyrings', async () => {
           const updatedVault =
             '{"vault": "updated_vault_detail", "salt": "salt"}';
           const keyringController = await initializeKeyringController({
@@ -850,45 +850,44 @@ describe('KeyringController', () => {
               cacheEncryptionKey: true,
             },
           });
-          const updateStateSpy = sinon.spy(
-            keyringController.memStore,
-            'updateState',
-          );
           const updateVaultStub = sinon
             .stub(
               keyringController.encryptor as ExportableKeyEncryptor,
-              'updateVaultWithDetail',
+              'updateVault',
             )
-            .resolves({
-              vault: updatedVault,
-              exportedKeyString: 'exported_key',
-            });
+            .resolves(updatedVault);
+          const persistAllKeyringsSpy = sinon.spy(
+            keyringController,
+            'persistAllKeyrings',
+          );
 
           await keyringController.unlockKeyrings(PASSWORD);
 
           expect(updateVaultStub.calledOnce).toBe(true);
-          expect(keyringController.store.getState().vault).toBe(updatedVault);
-          expect(
-            updateStateSpy.calledWith({
-              encryptionKey: 'exported_key',
-              encryptionSalt: 'salt',
-            }),
-          ).toBe(true);
+          expect(persistAllKeyringsSpy.called).toBe(true);
         });
       });
       describe('with cacheEncryptionKey = false', () => {
-        it('should update the vault to new format', async () => {
+        it('should call persistAllKeyrings', async () => {
           const updatedVault = '{"vault": "updated_vault", "salt": "salt"}';
           const keyringController = await initializeKeyringController({
             password: PASSWORD,
           });
-          sinon
-            .stub(keyringController.encryptor, 'updateVault')
+          const updateVaultStub = sinon
+            .stub(
+              keyringController.encryptor as ExportableKeyEncryptor,
+              'updateVault',
+            )
             .resolves(updatedVault);
+          const persistAllKeyringsSpy = sinon.spy(
+            keyringController,
+            'persistAllKeyrings',
+          );
 
           await keyringController.unlockKeyrings(PASSWORD);
 
-          expect(keyringController.store.getState().vault).toBe(updatedVault);
+          expect(updateVaultStub.calledOnce).toBe(true);
+          expect(persistAllKeyringsSpy.called).toBe(true);
         });
       });
     });

--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -817,9 +817,7 @@ class KeyringController extends EventEmitter {
           key,
           serializedKeyrings,
         );
-        if (encryptionSalt) {
-          vaultJSON.salt = encryptionSalt;
-        }
+        vaultJSON.salt = encryptionSalt;
         vault = JSON.stringify(vaultJSON);
       }
     } else {

--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -43,15 +43,15 @@ class KeyringController extends EventEmitter {
 
   public memStore: ObservableStore<KeyringControllerState>;
 
-  public encryptor: GenericEncryptor | KeyEncryptor;
-
   public keyrings: Keyring<Json>[];
-
-  public cacheEncryptionKey: boolean;
 
   public unsupportedKeyrings: SerializedKeyring[];
 
   public password?: string;
+
+  #encryptor: GenericEncryptor | KeyEncryptor;
+
+  #cacheEncryptionKey: boolean;
 
   constructor({
     keyringBuilders,
@@ -72,13 +72,16 @@ class KeyringController extends EventEmitter {
       keyrings: [],
     });
 
-    this.encryptor = encryptor;
+    this.#encryptor = encryptor;
     this.keyrings = [];
     this.unsupportedKeyrings = [];
 
     // This option allows the controller to cache an exported key
     // for use in decrypting and encrypting data without password
-    this.cacheEncryptionKey = Boolean(cacheEncryptionKey);
+    this.#cacheEncryptionKey = Boolean(cacheEncryptionKey);
+    if (this.#cacheEncryptionKey) {
+      assertIsKeyEncryptor(encryptor);
+    }
   }
 
   /**
@@ -797,9 +800,7 @@ class KeyringController extends EventEmitter {
     let newEncryptionKey;
 
     if (this.cacheEncryptionKey) {
-      if (!isKeyEncryptor(this.encryptor)) {
-        throw new Error(KeyringControllerError.UnsupportedKeyDecryption);
-      }
+      assertIsKeyEncryptor(this.encryptor);
 
       if (this.password) {
         const { vault: newVault, exportedKeyString } =
@@ -865,6 +866,8 @@ class KeyringController extends EventEmitter {
     encryptionKey?: string,
     encryptionSalt?: string,
   ): Promise<Keyring<Json>[]> {
+    await this.#updateVaultEncryption();
+
     const encryptedVault = this.store.getState().vault;
     if (!encryptedVault) {
       throw new Error(KeyringControllerError.VaultError);
@@ -875,9 +878,7 @@ class KeyringController extends EventEmitter {
     let vault;
 
     if (this.cacheEncryptionKey) {
-      if (!isKeyEncryptor(this.encryptor)) {
-        throw new Error(KeyringControllerError.UnsupportedKeyDecryption);
-      }
+      assertIsKeyEncryptor(this.encryptor);
 
       if (password) {
         const result = await this.encryptor.decryptWithDetail(
@@ -925,12 +926,60 @@ class KeyringController extends EventEmitter {
     }
 
     if (!isSerializedKeyringsArray(vault)) {
-      throw new Error(KeyringControllerError.VaultError);
+      throw new Error(KeyringControllerError.VaultDataError);
     }
 
     await Promise.all(vault.map(this.#restoreKeyring.bind(this)));
     await this.updateMemStoreKeyrings();
     return this.keyrings;
+  }
+
+  /**
+   * Setter for the encryptor.
+   *
+   * @param encryptor - The encryptor to set.
+   * @throws If the `cacheEncryptionKey` option is true and the
+   * encryptor is not a valid KeyEncryptor.
+   */
+  set encryptor(encryptor: GenericEncryptor | KeyEncryptor) {
+    if (this.cacheEncryptionKey) {
+      assertIsKeyEncryptor(encryptor);
+    }
+
+    this.#encryptor = encryptor;
+  }
+
+  /**
+   * Getter for the encryptor.
+   *
+   * @returns The encryptor.
+   */
+  get encryptor() {
+    return this.#encryptor;
+  }
+
+  /**
+   * Setter for the cacheEncryptionKey option.
+   *
+   * @param cache - Whether to cache the encryption key.
+   * @throws If the `cacheEncryptionKey` option is true and the
+   * encryptor is not a valid KeyEncryptor.
+   */
+  set cacheEncryptionKey(cache: boolean) {
+    if (cache) {
+      assertIsKeyEncryptor(this.encryptor);
+    }
+
+    this.#cacheEncryptionKey = cache;
+  }
+
+  /**
+   * Getter for the cacheEncryptionKey option.
+   *
+   * @returns Whether the encryption key is cached.
+   */
+  get cacheEncryptionKey() {
+    return this.#cacheEncryptionKey;
   }
 
   // =======================
@@ -1074,6 +1123,66 @@ class KeyringController extends EventEmitter {
 
     return keyring;
   }
+
+  /**
+   * Ensure that the vault is encrypted with the latest encryption method available.
+   *
+   * The vault is left unchanged if no password is available, if the encryptor does not support
+   * the vault update, or if the vault is already encrypted with the latest encryption method.
+   *
+   * @returns The updated encrypted vault.
+   */
+  async #updateVaultEncryption(): Promise<void> {
+    const encryptedVault = this.store.getState().vault;
+
+    if (!encryptedVault) {
+      throw new Error(KeyringControllerError.VaultError);
+    }
+
+    if (
+      !this.password ||
+      (!this.cacheEncryptionKey && !this.encryptor.updateVault)
+    ) {
+      return;
+    }
+
+    let updatedEncryptedVault: string;
+
+    if (this.cacheEncryptionKey) {
+      assertIsKeyEncryptor(this.encryptor);
+
+      const { vault, exportedKeyString } =
+        await this.encryptor.updateVaultWithDetail(
+          {
+            vault: encryptedVault,
+            exportedKeyString: '',
+          },
+          this.password,
+        );
+
+      if (encryptedVault !== vault) {
+        this.memStore.updateState({
+          encryptionKey: exportedKeyString,
+          encryptionSalt: JSON.parse(vault).salt,
+        });
+      }
+
+      updatedEncryptedVault = vault;
+    } else {
+      // @ts-expect-error This line is unreachable if `cacheEncryptionKey` is `false`
+      // and `encryptor.updateVault` is not defined.
+      updatedEncryptedVault = await this.encryptor.updateVault(
+        encryptedVault,
+        this.password,
+      );
+    }
+
+    if (encryptedVault !== updatedEncryptedVault) {
+      this.store.updateState({
+        vault: updatedEncryptedVault,
+      });
+    }
+  }
 }
 
 /**
@@ -1114,23 +1223,27 @@ async function displayForKeyring(
 }
 
 /**
- * Check if the provided encryptor supports
+ * Assert that the provided encryptor supports
  * key encryption.
  *
  * @param encryptor - The encryptor to check.
- * @returns True if the encryptor supports key encryption.
+ * @throws If the encryptor does not support key encryption.
  */
-function isKeyEncryptor(
+function assertIsKeyEncryptor(
   encryptor: GenericEncryptor | KeyEncryptor,
-): encryptor is KeyEncryptor {
-  return (
-    'importKey' in encryptor &&
-    typeof encryptor.importKey === 'function' &&
-    'decryptWithKey' in encryptor &&
-    typeof encryptor.decryptWithKey === 'function' &&
-    'encryptWithKey' in encryptor &&
-    typeof encryptor.encryptWithKey === 'function'
-  );
+): asserts encryptor is KeyEncryptor {
+  if (
+    !(
+      'importKey' in encryptor &&
+      typeof encryptor.importKey === 'function' &&
+      'decryptWithKey' in encryptor &&
+      typeof encryptor.decryptWithKey === 'function' &&
+      'encryptWithKey' in encryptor &&
+      typeof encryptor.encryptWithKey === 'function'
+    )
+  ) {
+    throw new Error(KeyringControllerError.UnsupportedKeyDecryption);
+  }
 }
 
 /**

--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -1156,17 +1156,11 @@ function assertIsExportableKeyEncryptor(
 function isSerializedKeyringsArray(
   array: unknown,
 ): array is SerializedKeyring[] {
-  if (typeof array !== 'object' || !Array.isArray(array)) {
-    return false;
-  }
-
-  for (const value of array) {
-    if (!value.type || !isValidJson(value.data)) {
-      return false;
-    }
-  }
-
-  return true;
+  return (
+    typeof array === 'object' &&
+    Array.isArray(array) &&
+    array.every((value) => value.type && isValidJson(value.data))
+  );
 }
 
 export { KeyringController, keyringBuilderFactory };

--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -1242,7 +1242,7 @@ function assertIsExportableKeyEncryptor(
       typeof encryptor.encryptWithKey === 'function'
     )
   ) {
-    throw new Error(KeyringControllerError.UnsupportedKeyDecryption);
+    throw new Error(KeyringControllerError.UnsupportedEncryptionKeyExport);
   }
 }
 

--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -28,7 +28,7 @@ import type {
   KeyringControllerState,
   KeyringControllerPersistentState,
   GenericEncryptor,
-  KeyEncryptor,
+  ExportableKeyEncryptor,
 } from './types';
 
 const defaultKeyringBuilders = [
@@ -49,7 +49,7 @@ class KeyringController extends EventEmitter {
 
   public password?: string;
 
-  #encryptor: GenericEncryptor | KeyEncryptor;
+  #encryptor: GenericEncryptor | ExportableKeyEncryptor;
 
   #cacheEncryptionKey: boolean;
 
@@ -80,7 +80,7 @@ class KeyringController extends EventEmitter {
     // for use in decrypting and encrypting data without password
     this.#cacheEncryptionKey = Boolean(cacheEncryptionKey);
     if (this.#cacheEncryptionKey) {
-      assertIsKeyEncryptor(encryptor);
+      assertIsExportableKeyEncryptor(encryptor);
     }
   }
 
@@ -800,7 +800,7 @@ class KeyringController extends EventEmitter {
     let newEncryptionKey;
 
     if (this.cacheEncryptionKey) {
-      assertIsKeyEncryptor(this.encryptor);
+      assertIsExportableKeyEncryptor(this.encryptor);
 
       if (this.password) {
         const { vault: newVault, exportedKeyString } =
@@ -878,7 +878,7 @@ class KeyringController extends EventEmitter {
     let vault;
 
     if (this.cacheEncryptionKey) {
-      assertIsKeyEncryptor(this.encryptor);
+      assertIsExportableKeyEncryptor(this.encryptor);
 
       if (password) {
         const result = await this.encryptor.decryptWithDetail(
@@ -939,11 +939,11 @@ class KeyringController extends EventEmitter {
    *
    * @param encryptor - The encryptor to set.
    * @throws If the `cacheEncryptionKey` option is true and the
-   * encryptor is not a valid KeyEncryptor.
+   * encryptor is not a valid ExportableKeyEncryptor.
    */
-  set encryptor(encryptor: GenericEncryptor | KeyEncryptor) {
+  set encryptor(encryptor: GenericEncryptor | ExportableKeyEncryptor) {
     if (this.cacheEncryptionKey) {
-      assertIsKeyEncryptor(encryptor);
+      assertIsExportableKeyEncryptor(encryptor);
     }
 
     this.#encryptor = encryptor;
@@ -963,11 +963,11 @@ class KeyringController extends EventEmitter {
    *
    * @param cache - Whether to cache the encryption key.
    * @throws If the `cacheEncryptionKey` option is true and the
-   * encryptor is not a valid KeyEncryptor.
+   * encryptor is not a valid ExportableKeyEncryptor.
    */
   set cacheEncryptionKey(cache: boolean) {
     if (cache) {
-      assertIsKeyEncryptor(this.encryptor);
+      assertIsExportableKeyEncryptor(this.encryptor);
     }
 
     this.#cacheEncryptionKey = cache;
@@ -1149,7 +1149,7 @@ class KeyringController extends EventEmitter {
     let updatedEncryptedVault: string;
 
     if (this.cacheEncryptionKey) {
-      assertIsKeyEncryptor(this.encryptor);
+      assertIsExportableKeyEncryptor(this.encryptor);
 
       const { vault, exportedKeyString } =
         await this.encryptor.updateVaultWithDetail(
@@ -1224,14 +1224,14 @@ async function displayForKeyring(
 
 /**
  * Assert that the provided encryptor supports
- * key encryption.
+ * encryption and encryption key export.
  *
  * @param encryptor - The encryptor to check.
  * @throws If the encryptor does not support key encryption.
  */
-function assertIsKeyEncryptor(
-  encryptor: GenericEncryptor | KeyEncryptor,
-): asserts encryptor is KeyEncryptor {
+function assertIsExportableKeyEncryptor(
+  encryptor: GenericEncryptor | ExportableKeyEncryptor,
+): asserts encryptor is ExportableKeyEncryptor {
   if (
     !(
       'importKey' in encryptor &&

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,7 @@ export enum KeyringControllerError {
   NoFirstAccount = 'KeyringController - First Account not found.',
   DuplicatedAccount = 'KeyringController - The account you are trying to import is a duplicate',
   VaultError = 'KeyringController - Cannot unlock without a previous vault.',
+  UnsupportedKeyDecryption = 'KeyringController - The encryptor does not support key decryption.',
   UnsupportedGenerateRandomMnemonic = 'KeyringController - The current keyring does not support the method generateRandomMnemonic.',
   UnsupportedExportAccount = '`KeyringController - The keyring for the current address does not support the method exportAccount',
   UnsupportedRemoveAccount = '`KeyringController - The keyring for the current address does not support the method removeAccount',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ export enum KeyringControllerError {
   DuplicatedAccount = 'KeyringController - The account you are trying to import is a duplicate',
   VaultError = 'KeyringController - Cannot unlock without a previous vault.',
   VaultDataError = 'KeyringController - The decrypted vault has an unexpected shape.',
-  UnsupportedKeyDecryption = 'KeyringController - The encryptor does not support key decryption.',
+  UnsupportedEncryptionKeyExport = 'KeyringController - The encryptor does not support encryption key export.',
   UnsupportedGenerateRandomMnemonic = 'KeyringController - The current keyring does not support the method generateRandomMnemonic.',
   UnsupportedExportAccount = '`KeyringController - The keyring for the current address does not support the method exportAccount',
   UnsupportedRemoveAccount = '`KeyringController - The keyring for the current address does not support the method removeAccount',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,7 @@ export enum KeyringControllerError {
   NoFirstAccount = 'KeyringController - First Account not found.',
   DuplicatedAccount = 'KeyringController - The account you are trying to import is a duplicate',
   VaultError = 'KeyringController - Cannot unlock without a previous vault.',
+  VaultDataError = 'KeyringController - The decrypted vault has an unexpected shape.',
   UnsupportedKeyDecryption = 'KeyringController - The encryptor does not support key decryption.',
   UnsupportedGenerateRandomMnemonic = 'KeyringController - The current keyring does not support the method generateRandomMnemonic.',
   UnsupportedExportAccount = '`KeyringController - The keyring for the current address does not support the method exportAccount',

--- a/src/test/encryptor.mock.ts
+++ b/src/test/encryptor.mock.ts
@@ -1,5 +1,7 @@
 import type { Json } from '@metamask/utils';
 
+import type { ExportableKeyEncryptor } from '../types';
+
 export const PASSWORD = 'password123';
 export const MOCK_ENCRYPTION_KEY = JSON.stringify({
   alg: 'A256GCM',
@@ -19,7 +21,7 @@ const INVALID_PASSWORD_ERROR = 'Incorrect password.';
 
 let cacheVal: Json;
 
-export class MockEncryptor {
+export class MockEncryptor implements ExportableKeyEncryptor {
   async encrypt(password: string, dataObj: any) {
     return JSON.stringify({
       ...(await this.encryptWithKey(password, dataObj)),
@@ -35,7 +37,7 @@ export class MockEncryptor {
     return cacheVal ?? {};
   }
 
-  async encryptWithKey(_key: string, dataObj: any) {
+  async encryptWithKey(_key: unknown, dataObj: any) {
     cacheVal = dataObj;
     return {
       data: MOCK_HEX,
@@ -58,8 +60,8 @@ export class MockEncryptor {
     };
   }
 
-  async decryptWithKey(key: string, text: string) {
-    return this.decrypt(key, text);
+  async decryptWithKey(key: unknown, text: string) {
+    return this.decrypt(key as string, text);
   }
 
   async keyFromPassword(_password: string) {

--- a/src/test/encryptor.mock.ts
+++ b/src/test/encryptor.mock.ts
@@ -1,8 +1,7 @@
 import type { Json } from '@metamask/utils';
-import { stub } from 'sinon';
 
-const PASSWORD = 'password123';
-const MOCK_ENCRYPTION_KEY = JSON.stringify({
+export const PASSWORD = 'password123';
+export const MOCK_ENCRYPTION_KEY = JSON.stringify({
   alg: 'A256GCM',
   ext: true,
   k: 'wYmxkxOOFBDP6F6VuuYFcRt_Po-tSLFHCWVolsHs4VI',
@@ -10,96 +9,88 @@ const MOCK_ENCRYPTION_KEY = JSON.stringify({
   key_ops: ['encrypt', 'decrypt'],
   kty: 'oct',
 });
-const MOCK_ENCRYPTION_SALT = 'HQ5sfhsb8XAQRJtD+UqcImT7Ve4n3YMagrh05YTOsjk=';
-const MOCK_ENCRYPTION_DATA = `{"data":"2fOOPRKClNrisB+tmqIcETyZvDuL2iIR1Hr1nO7XZHyMqVY1cDBetw2gY5C+cIo1qkpyv3bPp+4buUjp38VBsjbijM0F/FLOqWbcuKM9h9X0uwxsgsZ96uwcIf5I46NiMgoFlhppTTMZT0Nkocz+SnvHM0IgLsFan7JqBU++vSJvx2M1PDljZSunOsqyyL+DKmbYmM4umbouKV42dipUwrCvrQJmpiUZrSkpMJrPJk9ufDQO4CyIVo0qry3aNRdYFJ6rgSyq/k6rXMwGExCMHn8UlhNnAMuMKWPWR/ymK1bzNcNs4VU14iVjEXOZGPvD9cvqVe/VtcnIba6axNEEB4HWDOCdrDh5YNWwMlQVL7vSB2yOhPZByGhnEOloYsj2E5KEb9jFGskt7EKDEYNofr6t83G0c+B72VGYZeCvgtzXzgPwzIbhTtKkP+gdBmt2JNSYrTjLypT0q+v4C9BN1xWTxPmX6TTt0NzkI9pJxgN1VQAfSU9CyWTVpd4CBkgom2cSBsxZ2MNbdKF+qSWz3fQcmJ55hxM0EGJSt9+8eQOTuoJlBapRk4wdZKHR2jdKzPjSF2MAmyVD2kU51IKa/cVsckRFEes+m7dKyHRvlNwgT78W9tBDdZb5PSlfbZXnv8z5q1KtAj2lM2ogJ7brHBdevl4FISdTkObpwcUMcvACOOO0dj6CSYjSKr0ZJ2RLChVruZyPDxEhKGb/8Kv8trLOR3mck/et6d050/NugezycNk4nnzu5iP90gPbSzaqdZI=","iv":"qTGO1afGv3waHN9KoW34Eg==","salt":"${MOCK_ENCRYPTION_SALT}"}`;
-
-const INVALID_PASSWORD_ERROR = 'Incorrect password.';
-
-const MOCK_HARDCODED_KEY = 'key';
-const MOCK_HEX = '0xabcdef0123456789';
-const MOCK_SALT = 'SALT';
+export const MOCK_ENCRYPTION_SALT =
+  'HQ5sfhsb8XAQRJtD+UqcImT7Ve4n3YMagrh05YTOsjk=';
+export const MOCK_HARDCODED_KEY = 'key';
+export const MOCK_HEX = '0xabcdef0123456789';
 // eslint-disable-next-line no-restricted-globals
 const MOCK_KEY = Buffer.alloc(32);
+const INVALID_PASSWORD_ERROR = 'Incorrect password.';
+
 let cacheVal: Json;
 
-const mockEncryptor = {
-  encrypt: stub().callsFake(async (_password, dataObj) => {
-    cacheVal = dataObj;
-
-    return Promise.resolve(MOCK_HEX);
-  }),
-
-  encryptWithDetail: stub().callsFake(async (_password, dataObj) => {
-    cacheVal = dataObj;
-
-    return Promise.resolve({
-      vault: JSON.stringify({ salt: MOCK_HEX }),
-      exportedKeyString: MOCK_HARDCODED_KEY,
+export class MockEncryptor {
+  async encrypt(password: string, dataObj: any) {
+    return JSON.stringify({
+      ...(await this.encryptWithKey(password, dataObj)),
+      salt: this.generateSalt(),
     });
-  }),
+  }
 
   async decrypt(_password: string, _text: string) {
     if (_password && _password !== PASSWORD) {
       throw new Error(INVALID_PASSWORD_ERROR);
     }
 
-    return Promise.resolve(cacheVal ?? {});
-  },
+    return cacheVal ?? {};
+  }
 
-  async decryptWithEncryptedKeyString(_keyStr: string) {
-    const { vault } = await this.decryptWithDetail(_keyStr, 'mock vault');
-    return vault;
-  },
+  async encryptWithKey(_key: string, dataObj: any) {
+    cacheVal = dataObj;
+    return {
+      data: MOCK_HEX,
+      iv: 'anIv',
+    };
+  }
 
-  async decryptWithDetail(_password: string, _text: string) {
-    if (_password && _password !== PASSWORD) {
-      throw new Error(INVALID_PASSWORD_ERROR);
-    }
+  async encryptWithDetail(key: string, dataObj: any) {
+    return {
+      vault: await this.encrypt(key, dataObj),
+      exportedKeyString: MOCK_HARDCODED_KEY,
+    };
+  }
 
-    const result = cacheVal
-      ? {
-          vault: cacheVal,
-          exportedKeyString: MOCK_ENCRYPTION_KEY,
-          salt: MOCK_SALT,
-        }
-      : {};
-    return Promise.resolve(result);
-  },
+  async decryptWithDetail(key: string, text: string) {
+    return {
+      vault: await this.decrypt(key, text),
+      salt: MOCK_ENCRYPTION_SALT,
+      exportedKeyString: MOCK_ENCRYPTION_KEY,
+    };
+  }
 
-  importKey(keyString: string) {
-    if (keyString === '{}') {
+  async decryptWithKey(key: string, text: string) {
+    return this.decrypt(key, text);
+  }
+
+  async keyFromPassword(_password: string) {
+    return MOCK_KEY;
+  }
+
+  async importKey(key: string) {
+    if (key === '{}') {
       throw new TypeError(
         `Failed to execute 'importKey' on 'SubtleCrypto': The provided value is not of type '(ArrayBuffer or ArrayBufferView or JsonWebKey)'.`,
       );
     }
     return null;
-  },
+  }
 
-  encryptWithKey() {
-    const data = JSON.parse(MOCK_ENCRYPTION_DATA);
-    // Salt is not provided from this method
-    delete data.salt;
-    return data;
-  },
+  async updateVault(_vault: string, _password: string) {
+    return _vault;
+  }
 
-  async decryptWithKey(key: string, text: string) {
-    return this.decrypt(key, text);
-  },
-
-  async keyFromPassword(_password: string) {
-    return Promise.resolve(MOCK_KEY);
-  },
+  async updateVaultWithDetail(
+    encryptedData: any,
+    password: string,
+  ): Promise<any> {
+    const { vault } = encryptedData;
+    return {
+      ...encryptedData,
+      vault: await this.updateVault(vault, password),
+    };
+  }
 
   generateSalt() {
-    return 'WHADDASALT!';
-  },
-};
-
-export {
-  mockEncryptor,
-  PASSWORD,
-  MOCK_HARDCODED_KEY,
-  MOCK_HEX,
-  MOCK_ENCRYPTION_KEY,
-  MOCK_SALT,
-};
+    return MOCK_ENCRYPTION_SALT;
+  }
+}

--- a/src/test/encryptor.mock.ts
+++ b/src/test/encryptor.mock.ts
@@ -81,17 +81,6 @@ export class MockEncryptor implements ExportableKeyEncryptor {
     return _vault;
   }
 
-  async updateVaultWithDetail(
-    encryptedData: any,
-    password: string,
-  ): Promise<any> {
-    const { vault } = encryptedData;
-    return {
-      ...encryptedData,
-      vault: await this.updateVault(vault, password),
-    };
-  }
-
   generateSalt() {
     return MOCK_ENCRYPTION_SALT;
   }

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -1,19 +1,19 @@
 import {
-  mockEncryptor,
+  MockEncryptor,
   PASSWORD,
   MOCK_HARDCODED_KEY,
   MOCK_HEX,
   MOCK_ENCRYPTION_KEY,
-  MOCK_SALT,
+  MOCK_ENCRYPTION_SALT,
 } from './encryptor.mock';
 import KeyringMockWithInit from './keyring.mock';
 
 export {
-  mockEncryptor,
+  MockEncryptor,
   KeyringMockWithInit,
   PASSWORD,
   MOCK_HARDCODED_KEY,
   MOCK_HEX,
   MOCK_ENCRYPTION_KEY,
-  MOCK_SALT,
+  MOCK_ENCRYPTION_SALT,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,7 +93,7 @@ export type ExportableKeyEncryptor = GenericEncryptor & {
     salt?: string,
   ) => Promise<DetailedEncryptionResult>;
   /**
-   * Decrypts the given encrypted string with the given password.
+   * Decrypts the given encrypted string with the given encryption key.
    *
    * @param key - The encryption key to decrypt with.
    * @param encryptedString - The encrypted string to decrypt.

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export type KeyringControllerArgs = {
   keyringBuilders?: { (): Keyring<Json>; type: string }[];
   cacheEncryptionKey: boolean;
   initState?: KeyringControllerPersistentState;
-  encryptor?: any;
+  encryptor?: GenericEncryptor | KeyEncryptor;
 };
 
 export type KeyringObject = {
@@ -26,4 +26,38 @@ export type KeyringControllerState = {
 export type SerializedKeyring = {
   type: string;
   data: Json;
+};
+
+export type GenericEncryptor = {
+  encrypt: <Obj>(password: string, object: Obj) => Promise<string>;
+  decrypt: (password: string, encryptedString: string) => Promise<unknown>;
+};
+
+export type KeyEncryptor = GenericEncryptor & {
+  encryptWithKey: <Obj>(
+    key: unknown,
+    object: Obj,
+  ) => Promise<{
+    data: string;
+    iv: string;
+    salt?: string;
+  }>;
+  encryptWithDetail: <Obj>(
+    password: string,
+    object: Obj,
+    salt?: string,
+  ) => Promise<{
+    vault: string;
+    exportedKeyString: string;
+  }>;
+  decryptWithKey: (key: unknown, encryptedString: string) => Promise<unknown>;
+  decryptWithDetail: (
+    password: string,
+    encryptedString: string,
+  ) => Promise<{
+    salt: string;
+    vault: unknown;
+    exportedKeyString: string;
+  }>;
+  importKey: (key: string) => Promise<unknown>;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,8 +24,6 @@ export type KeyringControllerPersistentState = {
 export type KeyringControllerState = {
   keyrings: KeyringObject[];
   isUnlocked: boolean;
-  encryptionKey?: string;
-  encryptionSalt?: string;
 } & (
   | { encryptionKey: string; encryptionSalt: string }
   | {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,15 @@
+import type {
+  DetailedDecryptResult,
+  DetailedEncryptionResult,
+  EncryptionResult,
+} from '@metamask/browser-passworder';
 import type { Json, Keyring } from '@metamask/utils';
 
 export type KeyringControllerArgs = {
   keyringBuilders?: { (): Keyring<Json>; type: string }[];
-  cacheEncryptionKey: boolean;
   initState?: KeyringControllerPersistentState;
   encryptor?: GenericEncryptor | KeyEncryptor;
+  cacheEncryptionKey: boolean;
 };
 
 export type KeyringObject = {
@@ -31,33 +36,24 @@ export type SerializedKeyring = {
 export type GenericEncryptor = {
   encrypt: <Obj>(password: string, object: Obj) => Promise<string>;
   decrypt: (password: string, encryptedString: string) => Promise<unknown>;
+  updateVault?: (vault: string, password: string) => Promise<string>;
 };
 
 export type KeyEncryptor = GenericEncryptor & {
-  encryptWithKey: <Obj>(
-    key: unknown,
-    object: Obj,
-  ) => Promise<{
-    data: string;
-    iv: string;
-    salt?: string;
-  }>;
+  encryptWithKey: <Obj>(key: unknown, object: Obj) => Promise<EncryptionResult>;
   encryptWithDetail: <Obj>(
     password: string,
     object: Obj,
     salt?: string,
-  ) => Promise<{
-    vault: string;
-    exportedKeyString: string;
-  }>;
+  ) => Promise<DetailedEncryptionResult>;
   decryptWithKey: (key: unknown, encryptedString: string) => Promise<unknown>;
   decryptWithDetail: (
     password: string,
     encryptedString: string,
-  ) => Promise<{
-    salt: string;
-    vault: unknown;
-    exportedKeyString: string;
-  }>;
+  ) => Promise<DetailedDecryptResult>;
   importKey: (key: string) => Promise<unknown>;
+  updateVaultWithDetail: (
+    encryptedData: DetailedEncryptionResult,
+    password: string,
+  ) => Promise<DetailedEncryptionResult>;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,25 +33,103 @@ export type SerializedKeyring = {
   data: Json;
 };
 
+/**
+ * A generic encryptor interface that supports encrypting and decrypting
+ * serializable data with a password.
+ */
 export type GenericEncryptor = {
+  /**
+   * Encrypts the given object with the given password.
+   *
+   * @param password - The password to encrypt with.
+   * @param object - The object to encrypt.
+   * @returns The encrypted string.
+   */
   encrypt: <Obj>(password: string, object: Obj) => Promise<string>;
+  /**
+   * Decrypts the given encrypted string with the given password.
+   *
+   * @param password - The password to decrypt with.
+   * @param encryptedString - The encrypted string to decrypt.
+   * @returns The decrypted object.
+   */
   decrypt: (password: string, encryptedString: string) => Promise<unknown>;
+  /**
+   * Optional vault migration helper. Updates the provided vault, re-encrypting
+   * data with a safer algorithm if one is available.
+   *
+   * @param vault - The encrypted string to update.
+   * @param password - The password to decrypt the vault with.
+   * @returns The updated encrypted string.
+   */
   updateVault?: (vault: string, password: string) => Promise<string>;
 };
 
+/**
+ * An encryptor interface that supports encrypting and decrypting
+ * serializable data with a password, and exporting and importing keys.
+ */
 export type ExportableKeyEncryptor = GenericEncryptor & {
+  /**
+   * Encrypts the given object with the given encryption key.
+   *
+   * @param key - The encryption key to encrypt with.
+   * @param object - The object to encrypt.
+   * @returns The encryption result.
+   */
   encryptWithKey: <Obj>(key: unknown, object: Obj) => Promise<EncryptionResult>;
+  /**
+   * Encrypts the given object with the given password, and returns the
+   * encryption result and the exported key string.
+   *
+   * @param password - The password to encrypt with.
+   * @param object - The object to encrypt.
+   * @param salt - The optional salt to use for encryption.
+   * @returns The encrypted string and the exported key string.
+   */
   encryptWithDetail: <Obj>(
     password: string,
     object: Obj,
     salt?: string,
   ) => Promise<DetailedEncryptionResult>;
+  /**
+   * Decrypts the given encrypted string with the given password.
+   *
+   * @param key - The encryption key to decrypt with.
+   * @param encryptedString - The encrypted string to decrypt.
+   * @returns The decrypted object.
+   */
   decryptWithKey: (key: unknown, encryptedString: string) => Promise<unknown>;
+  /**
+   * Decrypts the given encrypted string with the given password, and returns
+   * the decrypted object and the salt and exported key string used for
+   * encryption.
+   *
+   * @param password - The password to decrypt with.
+   * @param encryptedString - The encrypted string to decrypt.
+   * @returns The decrypted object and the salt and exported key string used for
+   * encryption.
+   */
   decryptWithDetail: (
     password: string,
     encryptedString: string,
   ) => Promise<DetailedDecryptResult>;
+  /**
+   * Generates an encryption key from exported key string.
+   *
+   * @param key - The exported key string.
+   * @returns The encryption key.
+   */
   importKey: (key: string) => Promise<unknown>;
+  /**
+   * Vault migration helper. Updates the provided vault, re-encrypting
+   * data with a safer algorithm if one is available and returning it along with
+   * the updated exported key.
+   *
+   * @param encryptedData - The encrypted data to update.
+   * @param password - The password to decrypt the vault with.
+   * @returns The updated encrypted data and the updated exported key.
+   */
   updateVaultWithDetail: (
     encryptedData: DetailedEncryptionResult,
     password: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,9 +7,9 @@ import type { Json, Keyring } from '@metamask/utils';
 
 export type KeyringControllerArgs = {
   keyringBuilders?: { (): Keyring<Json>; type: string }[];
-  initState?: KeyringControllerPersistentState;
-  encryptor?: GenericEncryptor | KeyEncryptor;
   cacheEncryptionKey: boolean;
+  initState?: KeyringControllerPersistentState;
+  encryptor?: GenericEncryptor | ExportableKeyEncryptor;
 };
 
 export type KeyringObject = {
@@ -39,7 +39,7 @@ export type GenericEncryptor = {
   updateVault?: (vault: string, password: string) => Promise<string>;
 };
 
-export type KeyEncryptor = GenericEncryptor & {
+export type ExportableKeyEncryptor = GenericEncryptor & {
   encryptWithKey: <Obj>(key: unknown, object: Obj) => Promise<EncryptionResult>;
   encryptWithDetail: <Obj>(
     password: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,13 @@ export type KeyringControllerState = {
   isUnlocked: boolean;
   encryptionKey?: string;
   encryptionSalt?: string;
-};
+} & (
+  | { encryptionKey: string; encryptionSalt: string }
+  | {
+      encryptionKey?: never;
+      encryptionSalt?: never;
+    }
+);
 
 export type SerializedKeyring = {
   type: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,7 @@ export type GenericEncryptor = {
    * @param object - The object to encrypt.
    * @returns The encrypted string.
    */
-  encrypt: <Obj>(password: string, object: Obj) => Promise<string>;
+  encrypt: (password: string, object: Json) => Promise<string>;
   /**
    * Decrypts the given encrypted string with the given password.
    *
@@ -77,7 +77,7 @@ export type ExportableKeyEncryptor = GenericEncryptor & {
    * @param object - The object to encrypt.
    * @returns The encryption result.
    */
-  encryptWithKey: <Obj>(key: unknown, object: Obj) => Promise<EncryptionResult>;
+  encryptWithKey: (key: unknown, object: Json) => Promise<EncryptionResult>;
   /**
    * Encrypts the given object with the given password, and returns the
    * encryption result and the exported key string.
@@ -87,9 +87,9 @@ export type ExportableKeyEncryptor = GenericEncryptor & {
    * @param salt - The optional salt to use for encryption.
    * @returns The encrypted string and the exported key string.
    */
-  encryptWithDetail: <Obj>(
+  encryptWithDetail: (
     password: string,
-    object: Obj,
+    object: Json,
     salt?: string,
   ) => Promise<DetailedEncryptionResult>;
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,17 +121,4 @@ export type ExportableKeyEncryptor = GenericEncryptor & {
    * @returns The encryption key.
    */
   importKey: (key: string) => Promise<unknown>;
-  /**
-   * Vault migration helper. Updates the provided vault, re-encrypting
-   * data with a safer algorithm if one is available and returning it along with
-   * the updated exported key.
-   *
-   * @param encryptedData - The encrypted data to update.
-   * @param password - The password to decrypt the vault with.
-   * @returns The updated encrypted data and the updated exported key.
-   */
-  updateVaultWithDetail: (
-    encryptedData: DetailedEncryptionResult,
-    password: string,
-  ) => Promise<DetailedEncryptionResult>;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,10 +7,14 @@ import type { Json, Keyring } from '@metamask/utils';
 
 export type KeyringControllerArgs = {
   keyringBuilders?: { (): Keyring<Json>; type: string }[];
-  cacheEncryptionKey: boolean;
   initState?: KeyringControllerPersistentState;
-  encryptor?: GenericEncryptor | ExportableKeyEncryptor;
-};
+} & (
+  | { encryptor?: ExportableKeyEncryptor; cacheEncryptionKey: true }
+  | {
+      encryptor?: GenericEncryptor | ExportableKeyEncryptor;
+      cacheEncryptionKey: false;
+    }
+);
 
 export type KeyringObject = {
   type: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1154,10 +1154,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/browser-passworder@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@metamask/browser-passworder@npm:4.1.0"
-  checksum: f1edb3b75594b8e8d075b3134c9ce6c73573160eb48184ef722b9d96a5763db1e2e9acb166fc5c66c7c82936e134a02a3fb4c0022ca9a948857a30181cb84d7e
+"@metamask/browser-passworder@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "@metamask/browser-passworder@npm:4.2.0"
+  dependencies:
+    "@metamask/utils": ^8.2.0
+  checksum: 03b76357942d25a6316d6a03a8bc839cb18e53d9f95fc2787e0fbbcf13eeb2485ece47a2758e928d04635f8dbaa598794f2ecd0313e7c91f989bf11f2a0adec5
   languageName: node
   linkType: hard
 
@@ -1233,7 +1235,7 @@ __metadata:
     "@lavamoat/allow-scripts": ^2.3.1
     "@lavamoat/preinstall-always-fail": ^1.0.0
     "@metamask/auto-changelog": ^3.0.0
-    "@metamask/browser-passworder": ^4.1.0
+    "@metamask/browser-passworder": ^4.2.0
     "@metamask/eslint-config": ^12.2.0
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
@@ -1242,7 +1244,7 @@ __metadata:
     "@metamask/eth-sig-util": ^7.0.0
     "@metamask/eth-simple-keyring": ^6.0.1
     "@metamask/obs-store": ^8.1.0
-    "@metamask/utils": ^8.1.0
+    "@metamask/utils": ^8.2.0
     "@types/jest": ^29.4.0
     "@types/node": ^16.18.46
     "@types/sinon": ^10.0.13
@@ -1329,7 +1331,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^8.0.0, @metamask/utils@npm:^8.1.0":
+"@metamask/utils@npm:^8.0.0, @metamask/utils@npm:^8.1.0, @metamask/utils@npm:^8.2.0":
   version: 8.2.1
   resolution: "@metamask/utils@npm:8.2.1"
   dependencies:


### PR DESCRIPTION
## Description

Currently `encryptor` type is `any`, and as different clients can use different encryptor utilities, we need to establish a minimum supported (or needed) interface that the encryptor should implement.

This PR adds some types and guards to the encryptor, taking into account `@metamask/browser-passworder`, which is the encryptor used by the extension, and the [Encryptor class](https://github.com/MetaMask/metamask-mobile/blob/main/app/core/Encryptor.js) used by mobile

Restrictions have also been added for `cacheEncryptionKey` and `encryptor`, as the methods that the encryptor must support depends on whether we need the encryption key to be exported or not. To do this, public class variables have been substituted with sharp vars and a check on construction has been added: an error is thrown when they are incompatible 

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are you introducing a breaking change  (renaming, removing, or changing a part of a public-facing interface)?
-->

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

- **BREAKING**: `encryptor` class variable is now inaccessible
- **BREAKING**: `cacheEncryptionKey` class variable is now inaccessible
- **BREAKING**: `encryptor` constructor option type has been changed to `GenericEncryptor | ExportableKeyEncryptor | undefined`

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Waiting on https://github.com/MetaMask/browser-passworder/pull/49
* Fixes #295 

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
