### PR TITLE
feat!: create new vault with any keyring

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 80.35,
-      functions: 93.65,
-      lines: 91.9,
-      statements: 92.07,
+      branches: 80.18,
+      functions: 93.54,
+      lines: 91.69,
+      statements: 91.87,
     },
   },
   preset: 'ts-jest',

--- a/src/KeyringController.test.ts
+++ b/src/KeyringController.test.ts
@@ -67,12 +67,17 @@ async function initializeKeyringController({
   if (seedPhrase && !password) {
     throw new Error('Password required to restore vault');
   } else if (seedPhrase && password) {
-    await keyringController.createNewVaultAndRestore(
-      PASSWORD,
-      walletOneSeedWords,
-    );
+    await keyringController.createNewVaultWithKeyring(PASSWORD, {
+      type: KeyringType.HD,
+      opts: {
+        mnemonic: walletOneSeedWords,
+        numberOfAccounts: 1,
+      },
+    });
   } else if (password) {
-    await keyringController.createNewVaultAndKeychain(PASSWORD);
+    await keyringController.createNewVaultWithKeyring(PASSWORD, {
+      type: KeyringType.HD,
+    });
   }
 
   return keyringController;
@@ -162,7 +167,9 @@ describe('KeyringController', () => {
       const keyringController = await initializeKeyringController({
         password: PASSWORD,
       });
-      await keyringController.createNewVaultAndKeychain(PASSWORD);
+      await keyringController.createNewVaultWithKeyring(PASSWORD, {
+        type: KeyringType.HD,
+      });
       await keyringController.persistAllKeyrings();
       expect(keyringController.keyrings).toHaveLength(1);
 
@@ -257,7 +264,9 @@ describe('KeyringController', () => {
               cacheEncryptionKey: true,
             },
           });
-          await keyringController.createNewVaultAndKeychain(PASSWORD);
+          await keyringController.createNewVaultWithKeyring(PASSWORD, {
+            type: KeyringType.HD,
+          });
           deleteEncryptionKeyAndSalt(keyringController);
 
           const response = await keyringController.persistAllKeyrings();
@@ -303,8 +312,11 @@ describe('KeyringController', () => {
       keyringController.store.putState({});
       assert(!keyringController.store.getState().vault, 'no previous vault');
 
-      const newVault = await keyringController.createNewVaultAndKeychain(
+      const newVault = await keyringController.createNewVaultWithKeyring(
         PASSWORD,
+        {
+          type: KeyringType.HD,
+        },
       );
       const { vault } = keyringController.store.getState();
       expect(vault).toStrictEqual(expect.stringMatching('.+'));
@@ -318,7 +330,9 @@ describe('KeyringController', () => {
       keyringController.store.putState({});
       assert(!keyringController.store.getState().vault, 'no previous vault');
 
-      await keyringController.createNewVaultAndKeychain(PASSWORD);
+      await keyringController.createNewVaultWithKeyring(PASSWORD, {
+        type: KeyringType.HD,
+      });
       const { isUnlocked } = keyringController.memStore.getState();
       expect(isUnlocked).toBe(true);
     });
@@ -335,7 +349,9 @@ describe('KeyringController', () => {
       keyringController.store.putState({});
       assert(!keyringController.store.getState().vault, 'no previous vault');
 
-      await keyringController.createNewVaultAndKeychain(PASSWORD);
+      await keyringController.createNewVaultWithKeyring(PASSWORD, {
+        type: KeyringType.HD,
+      });
       const { vault } = keyringController.store.getState();
       // eslint-disable-next-line jest/no-restricted-matchers
       expect(vault).toBeTruthy();
@@ -353,8 +369,10 @@ describe('KeyringController', () => {
         .mockImplementation(async () => Promise.resolve([]));
 
       await expect(async () =>
-        keyringController.createNewVaultAndKeychain(PASSWORD),
-      ).rejects.toThrow(KeyringControllerError.NoAccountOnKeychain);
+        keyringController.createNewVaultWithKeyring(PASSWORD, {
+          type: KeyringType.HD,
+        }),
+      ).rejects.toThrow(KeyringControllerError.NoFirstAccount);
     });
 
     describe('when `cacheEncryptionKey` is enabled', () => {
@@ -366,7 +384,9 @@ describe('KeyringController', () => {
           },
         });
 
-        await keyringController.createNewVaultAndKeychain(PASSWORD);
+        await keyringController.createNewVaultWithKeyring(PASSWORD, {
+          type: KeyringType.HD,
+        });
 
         const finalMemStore = keyringController.memStore.getState();
         expect(finalMemStore.encryptionKey).toBe(MOCK_HARDCODED_KEY);
@@ -387,10 +407,13 @@ describe('KeyringController', () => {
       const allAccounts = await keyringController.getAccounts();
       expect(allAccounts).toHaveLength(2);
 
-      await keyringController.createNewVaultAndRestore(
-        PASSWORD,
-        walletOneSeedWords,
-      );
+      await keyringController.createNewVaultWithKeyring(PASSWORD, {
+        type: KeyringType.HD,
+        opts: {
+          mnemonic: walletOneSeedWords,
+          numberOfAccounts: 1,
+        },
+      });
 
       const allAccountsAfter = await keyringController.getAccounts();
       expect(allAccountsAfter).toHaveLength(1);
@@ -403,7 +426,13 @@ describe('KeyringController', () => {
       });
       await expect(async () =>
         // @ts-expect-error Missing other required permission types.
-        keyringController.createNewVaultAndRestore(12, walletTwoSeedWords),
+        keyringController.createNewVaultWithKeyring(12, {
+          type: KeyringType.HD,
+          opts: {
+            mnemonic: walletTwoSeedWords,
+            numberOfAccounts: 1,
+          },
+        }),
       ).rejects.toThrow('KeyringController - Password must be of type string.');
     });
 
@@ -412,16 +441,26 @@ describe('KeyringController', () => {
         password: PASSWORD,
       });
       await expect(async () =>
-        keyringController.createNewVaultAndRestore(
-          PASSWORD,
-          'test test test palace city barely security section midnight wealth south deer',
-        ),
+        keyringController.createNewVaultWithKeyring(PASSWORD, {
+          type: KeyringType.HD,
+          opts: {
+            mnemonic:
+              'test test test palace city barely security section midnight wealth south deer',
+            numberOfAccounts: 1,
+          },
+        }),
       ).rejects.toThrow(
         'Eth-Hd-Keyring: Invalid secret recovery phrase provided',
       );
 
       await expect(async () =>
-        keyringController.createNewVaultAndRestore(PASSWORD, '1234'),
+        keyringController.createNewVaultWithKeyring(PASSWORD, {
+          type: KeyringType.HD,
+          opts: {
+            mnemonic: '1234',
+            numberOfAccounts: 1,
+          },
+        }),
       ).rejects.toThrow(
         'Eth-Hd-Keyring: Invalid secret recovery phrase provided',
       );
@@ -437,10 +476,13 @@ describe('KeyringController', () => {
         Buffer.from(walletTwoSeedWords).values(),
       );
 
-      await keyringController.createNewVaultAndRestore(
-        PASSWORD,
-        mnemonicAsArrayOfNumbers,
-      );
+      await keyringController.createNewVaultWithKeyring(PASSWORD, {
+        type: KeyringType.HD,
+        opts: {
+          mnemonic: mnemonicAsArrayOfNumbers,
+          numberOfAccounts: 1,
+        },
+      });
 
       const allAccountsAfter = await keyringController.getAccounts();
       expect(allAccountsAfter).toHaveLength(1);
@@ -456,10 +498,13 @@ describe('KeyringController', () => {
         .mockImplementation(async () => Promise.resolve([]));
 
       await expect(async () =>
-        keyringController.createNewVaultAndRestore(
-          PASSWORD,
-          walletTwoSeedWords,
-        ),
+        keyringController.createNewVaultWithKeyring(PASSWORD, {
+          type: KeyringType.HD,
+          opts: {
+            mnemonic: walletTwoSeedWords,
+            numberOfAccounts: 1,
+          },
+        }),
       ).rejects.toThrow('KeyringController - First Account not found.');
     });
 
@@ -472,10 +517,13 @@ describe('KeyringController', () => {
           },
         });
 
-        await keyringController.createNewVaultAndRestore(
-          PASSWORD,
-          walletOneSeedWords,
-        );
+        await keyringController.createNewVaultWithKeyring(PASSWORD, {
+          type: KeyringType.HD,
+          opts: {
+            mnemonic: walletOneSeedWords,
+            numberOfAccounts: 1,
+          },
+        });
 
         const finalMemStore = keyringController.memStore.getState();
         expect(finalMemStore.encryptionKey).toBe(MOCK_HARDCODED_KEY);
@@ -943,10 +991,13 @@ describe('KeyringController', () => {
     it('does not throw if a vault exists in state', async () => {
       const keyringController = await initializeKeyringController();
 
-      await keyringController.createNewVaultAndRestore(
-        PASSWORD,
-        walletOneSeedWords,
-      );
+      await keyringController.createNewVaultWithKeyring(PASSWORD, {
+        type: KeyringType.HD,
+        opts: {
+          mnemonic: walletOneSeedWords,
+          numberOfAccounts: 1,
+        },
+      });
 
       expect(async () =>
         keyringController.verifyPassword(PASSWORD),
@@ -1273,10 +1324,13 @@ describe('KeyringController', () => {
       const keyringController = await initializeKeyringController({
         password: PASSWORD,
       });
-      await keyringController.createNewVaultAndRestore(
-        PASSWORD,
-        walletOneSeedWords,
-      );
+      await keyringController.createNewVaultWithKeyring(PASSWORD, {
+        type: KeyringType.HD,
+        opts: {
+          mnemonic: walletOneSeedWords,
+          numberOfAccounts: 1,
+        },
+      });
       const privateKey = await keyringController.exportAccount(
         // @ts-expect-error this value should never be undefined in this specific context.
         walletOneAddresses[0],

--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -115,43 +115,25 @@ class KeyringController extends EventEmitter {
    */
 
   /**
-   * Create New Vault And Keychain
+   * Create new vault And with a specific keyring
    *
    * Destroys any old encrypted storage,
    * creates a new encrypted store with the given password,
-   * randomly creates a new HD wallet with 1 account,
-   * faucets that account on the testnet.
+   * creates a new wallet with 1 account.
    *
    * @fires KeyringController#unlock
    * @param password - The password to encrypt the vault with.
+   * @param keyring - A object containing the params to instantiate a new keyring.
+   * @param keyring.type - The keyring type.
+   * @param keyring.opts - Optional parameters required to instantiate the keyring.
    * @returns A promise that resolves to the state.
    */
-  async createNewVaultAndKeychain(
+  async createNewVaultWithKeyring(
     password: string,
-  ): Promise<KeyringControllerState> {
-    this.password = password;
-
-    await this.#createFirstKeyTree();
-    this.#setUnlocked();
-    return this.fullUpdate();
-  }
-
-  /**
-   * CreateNewVaultAndRestore
-   *
-   * Destroys any old encrypted storage,
-   * creates a new encrypted store with the given password,
-   * creates a new HD wallet from the given seed with 1 account.
-   *
-   * @fires KeyringController#unlock
-   * @param password - The password to encrypt the vault with.
-   * @param seedPhrase - The BIP39-compliant seed phrase,
-   * either as a string or Uint8Array.
-   * @returns A promise that resolves to the state.
-   */
-  async createNewVaultAndRestore(
-    password: string,
-    seedPhrase: Uint8Array | string | number[],
+    keyring: {
+      type: string;
+      opts?: unknown;
+    },
   ): Promise<KeyringControllerState> {
     if (typeof password !== 'string') {
       throw new TypeError(KeyringControllerError.WrongPasswordType);
@@ -159,16 +141,7 @@ class KeyringController extends EventEmitter {
     this.password = password;
 
     await this.#clearKeyrings();
-    const keyring = await this.addNewKeyring(KeyringType.HD, {
-      mnemonic: seedPhrase,
-      numberOfAccounts: 1,
-    });
-
-    const [firstAccount] = await keyring.getAccounts();
-
-    if (!firstAccount) {
-      throw new Error(KeyringControllerError.NoFirstAccount);
-    }
+    await this.#createKeyring(keyring.type, keyring.opts);
     this.#setUnlocked();
     return this.fullUpdate();
   }

--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -984,28 +984,24 @@ class KeyringController extends EventEmitter {
   // =======================
 
   /**
-   * Create First Key Tree.
+   * Create keyring.
    *
-   * - Clears the existing vault.
    * - Creates a new vault.
-   * - Creates a random new HD Keyring with 1 account.
+   * - Creates a new keyring with one account.
    * - Makes that account the selected account.
-   * - Faucets that account on testnet.
-   * - Puts the current seed words into the state tree.
-   *
+   * @param type - Keyring type to instantiate.
+   * @param opts - Optional parameters required to instantiate the keyring.
    * @returns A promise that resolves if the operation was successful.
    */
-  async #createFirstKeyTree(): Promise<null> {
-    await this.#clearKeyrings();
-
-    const keyring = await this.addNewKeyring(KeyringType.HD);
+  async #createKeyring(type: string, opts?: unknown): Promise<null> {
+    const keyring = await this.addNewKeyring(type, opts);
     if (!keyring) {
       throw new Error(KeyringControllerError.NoKeyring);
     }
 
     const [firstAccount] = await keyring.getAccounts();
     if (!firstAccount) {
-      throw new Error(KeyringControllerError.NoAccountOnKeychain);
+      throw new Error(KeyringControllerError.NoFirstAccount);
     }
 
     const hexAccount = normalizeToHex(firstAccount);

--- a/src/KeyringController.ts
+++ b/src/KeyringController.ts
@@ -987,8 +987,8 @@ class KeyringController extends EventEmitter {
    * Create keyring.
    *
    * - Creates a new vault.
-   * - Creates a new keyring with one account.
-   * - Makes that account the selected account.
+   * - Creates a new keyring with at least one account.
+   * - Makes the first account the selected account.
    * @param type - Keyring type to instantiate.
    * @param opts - Optional parameters required to instantiate the keyring.
    * @returns A promise that resolves if the operation was successful.


### PR DESCRIPTION
## Description

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are you introducing a breaking change  (renaming, removing, or changing a part of a public-facing interface)?
-->

This change updates the logic inside the `eth-keyring-controller` to allow the creation of a vault with any keyring. This removes the hardcoded HD Keyring from the code and allow the client to pass the parameters to instantiate any keyring that is accepted by the controller.

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

- **BREAKING**: Unify `createNewVaultAndKeychain` and `createNewVaultAndRestore` into new method `createNewVaultWithKeyring`. `createNewVaultWithKeyring` accepts a password and a keyring object provided by the client and returns the `KeyringControllerState`

## References

No references

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
