### PR TITLE
Set maintenance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Eth Keyring Controller
 
+> [!WARNING]
+> This package has been merged with [`@metamask/keyring-controller`](https://github.com/MetaMask/core/tree/main/packages/keyring-controller).
+> This repository is in maintenance mode and PRs will no longer be accepted, with the exception of security changes.
+
 A module for managing groups of Ethereum accounts called "Keyrings", defined originally for MetaMask's multiple-account-type feature.
 
 To add new account types to a `KeyringController`, just make sure it follows [The Keyring Class Protocol](./docs/keyring.md).


### PR DESCRIPTION
## Description

This PR adds a warning on the main README, to inform package users and devs that EthKeyringController has been moved to the core monorepo, and merged into KeyringController.

Because of that, PRs will no longer be accepted, with the exception of security patches. 

## Changes

<!--
Pretend that you're updating a changelog. How would you categorize your changes?

CATEGORY is one of:

- BREAKING
- ADDED
- CHANGED
- DEPRECATED
- REMOVED
- FIXED

(Security-related changes should go through the Security Advisory process.)
-->

No functional changes

## References

<!--
Are there any issues or other links that reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

* Fixes https://github.com/MetaMask/core/issues/3768

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation for new or updated code as appropriate (note: this will usually be JSDoc)
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
